### PR TITLE
Evaluate IEnumerable immediately when deserializing

### DIFF
--- a/src/graphql.server.links/DTOs/ObjectDictionaryConverter.cs
+++ b/src/graphql.server.links/DTOs/ObjectDictionaryConverter.cs
@@ -113,7 +113,7 @@ namespace Tanka.GraphQL.Server.Links.DTOs
                         yield return null;
                         break;
                     case JsonValueKind.Array:
-                        yield return ReadArray(item, options);
+                        yield return ReadArray(item, options).ToList();
                         break;
                     default:
                         throw new InvalidOperationException($"Unexpected value kind: {item.ValueKind}");


### PR DESCRIPTION
to avoid exception later when JsonDocument has been disposed.