### PR TITLE
Abstracts number parsing for re-use

### DIFF
--- a/src/graphql.server.links/DTOs/ObjectDictionaryConverter.cs
+++ b/src/graphql.server.links/DTOs/ObjectDictionaryConverter.cs
@@ -17,14 +17,6 @@ namespace Tanka.GraphQL.Server.Links.DTOs
             return ReadDictionary(doc.RootElement, options);
         }
 
-        private void EnsureTokenType(JsonTokenType actual, JsonTokenType expected)
-        {
-            if (actual != expected)
-                throw new InvalidOperationException(
-                    $"Unexpected token type '{actual}' expected '{expected}'");
-        }
-
-
         public override void Write(Utf8JsonWriter writer, Dictionary<string, object> value,
             JsonSerializerOptions options)
         {

--- a/src/graphql.server.links/DTOs/ObjectDictionaryConverter.cs
+++ b/src/graphql.server.links/DTOs/ObjectDictionaryConverter.cs
@@ -52,12 +52,7 @@ namespace Tanka.GraphQL.Server.Links.DTOs
                         resultValue = ReadDictionary(value, options);
                         break;
                     case JsonValueKind.Number:
-                        if (value.TryGetInt32(out var i))
-                            resultValue = i;
-                        else if (value.TryGetDouble(out var d))
-                            resultValue = d;
-                        else if (value.TryGetDecimal(out var dd))
-                            resultValue = dd;
+                        resultValue = ReadNumber(value);
                         break;
                     case JsonValueKind.True:
                     case JsonValueKind.False:
@@ -95,12 +90,7 @@ namespace Tanka.GraphQL.Server.Links.DTOs
                         yield return ReadDictionary(item, options);
                         break;
                     case JsonValueKind.Number:
-                        if (item.TryGetInt32(out var i))
-                            yield return i;
-                        else if (item.TryGetDouble(out var d))
-                            yield return d;
-                        else if (item.TryGetDecimal(out var dd))
-                            yield return dd;
+                        yield return ReadNumber(item);
                         break;
                     case JsonValueKind.True:
                     case JsonValueKind.False:
@@ -119,6 +109,20 @@ namespace Tanka.GraphQL.Server.Links.DTOs
                         throw new InvalidOperationException($"Unexpected value kind: {item.ValueKind}");
                 }
             }
+        }
+        
+        private object ReadNumber(JsonElement value)
+        {
+            if (value.TryGetInt32(out var i))
+                return i;
+            else if (value.TryGetInt64(out var l))
+                return l;
+            else if (value.TryGetDouble(out var d))
+                return d;
+            else if (value.TryGetDecimal(out var dd))
+                return dd;
+
+            throw new NotImplementedException($"Unexpected Number value. Raw text was: {value.GetRawText()}");
         }
 
         private void WriteDictionary(Utf8JsonWriter writer, Dictionary<string, object> dictionary,


### PR DESCRIPTION
Also:
* adds int64, which you may or may not want.
* removes unused method `EnsureTokenType`.