### PR TITLE
Fix applying directives when building a schema

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -67,7 +67,9 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: |
+            - 3.1.x
+            - 6.0.x
 
     - name: Build packages
       shell: pwsh

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -68,8 +68,8 @@ jobs:
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: |
-            - 3.1.x
-            - 6.0.x
+            3.1.x
+            6.0.x
 
     - name: Build packages
       shell: pwsh

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,8 +26,8 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: |
-            6.0.x
             3.1.x
+            6.0.x
 
       - name: Build docs
         shell: pwsh

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -29,8 +29,8 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: |
-            - 3.1.x
-            - 6.0.x
+            3.1.x
+            6.0.x
 
       - name: Build packages
         shell: pwsh

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -28,7 +28,9 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 6.0.x
+          dotnet-version: |
+            - 3.1.x
+            - 6.0.x
 
       - name: Build packages
         shell: pwsh

--- a/build.ps1
+++ b/build.ps1
@@ -64,13 +64,14 @@ $IsPreRelease = $PreReleaseTag -ne ''
 # Build and test
 "----------------------------------------"
 "Build"
-dotnet build -c Release
+dotnet restore
+dotnet build -c Release --no-restore
 EnsureLastExitCode("dotnet build failed")
 
 if ($OnlyBuild -eq $False) {
     "----------------------------------------"
     "Run tests"
-    dotnet test -c Release --logger trx -r $Output
+    dotnet test -c Release --logger trx -r $Output --no-restore --no-build
     EnsureLastExitCode("dotnet test failed")
 
     "----------------------------------------"

--- a/src/graphql.language/DocumentWalkerContextBase.cs
+++ b/src/graphql.language/DocumentWalkerContextBase.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using Tanka.GraphQL.Language.Nodes;
 
 namespace Tanka.GraphQL.Language;

--- a/src/graphql.language/Nodes/ListValue.cs
+++ b/src/graphql.language/Nodes/ListValue.cs
@@ -5,14 +5,13 @@ namespace Tanka.GraphQL.Language.Nodes;
 
 public sealed class ListValue : ValueBase, ICollectionNode<ValueBase>
 {
-    //todo: remove?
-    public readonly IReadOnlyList<ValueBase> Values;
+    private readonly IReadOnlyList<ValueBase> _values;
 
     public ListValue(
         IReadOnlyList<ValueBase> values,
         in Location? location = default)
     {
-        Values = values;
+        _values = values;
         Location = location;
     }
 
@@ -22,14 +21,14 @@ public sealed class ListValue : ValueBase, ICollectionNode<ValueBase>
 
     public IEnumerator<ValueBase> GetEnumerator()
     {
-        return Values.GetEnumerator();
+        return _values.GetEnumerator();
     }
 
     IEnumerator IEnumerable.GetEnumerator()
     {
-        return ((IEnumerable)Values).GetEnumerator();
+        return ((IEnumerable)_values).GetEnumerator();
     }
 
-    public int Count => Values.Count;
-    public ValueBase this[int index] => Values[index];
+    public int Count => _values.Count;
+    public ValueBase this[int index] => _values[index];
 }

--- a/src/graphql.language/Nodes/TypeSystem/Import.cs
+++ b/src/graphql.language/Nodes/TypeSystem/Import.cs
@@ -28,7 +28,7 @@ public sealed class Import : INode
         var types = string.Empty;
 
         if (Types is not null)
-            types = $" {string.Join(',', Types.Select(t => t.Value))}";
+            types = $" {string.Join(",", Types.Select(t => t.Value))}";
 
         return $"tanka_import{types} from \"{From}\"";
     }

--- a/src/graphql.language/Parser.cs
+++ b/src/graphql.language/Parser.cs
@@ -349,7 +349,6 @@ public ref partial struct Parser
 
     public EnumValue ParseEnumValue()
     {
-        //todo: maybe this should be kept as byte[]?
         var enumName = ParseName();
         return new EnumValue(enumName, enumName.Location);
     }

--- a/src/graphql.language/Printer.cs
+++ b/src/graphql.language/Printer.cs
@@ -23,12 +23,12 @@ public class PrinterContext : DocumentWalkerContextBase
 
     public void AppendJoin(char separator, IEnumerable<object> items)
     {
-        _builder.AppendJoin(separator, items);
+        _builder.Append(string.Join($"{separator}", items));
     }
 
     public bool EndsWith(char c)
     {
-        return _builder[^1] == c;
+        return _builder[_builder.Length-1] == c;
     }
 
     public void Rewind()

--- a/src/graphql.language/Shims/netstandard20.cs
+++ b/src/graphql.language/Shims/netstandard20.cs
@@ -1,0 +1,50 @@
+﻿using System.Collections.Generic;
+
+#if !NETSTANDARD2_1
+namespace System
+{
+    internal static class Extensions
+    {
+        public static void Deconstruct<K, V>(this KeyValuePair<K, V> pair, out K key, out V value)
+        {
+            key = pair.Key;
+            value = pair.Value;
+        }
+
+        public static bool TryPop<T>(this Stack<T> stack, out T? value)
+        {
+            if (stack.Count == 0)
+            {
+                value = default;
+                return false;
+            }
+
+            value = stack.Pop();
+            return true;
+        }
+
+        public static bool TryPeek<T>(this Stack<T> stack, out T? value)
+        {
+            if (stack.Count == 0)
+            {
+                value = default;
+                return false;
+            }
+
+            value = stack.Peek();
+            return true;
+        }
+    }
+
+    namespace Text
+    {
+        internal static class EncodingExtensions
+        {
+            public static string GetString(this Encoding encoding, in ReadOnlySpan<byte> span)
+            {
+                return encoding.GetString(span.ToArray());
+            }
+        }
+    }
+}
+#endif

--- a/src/graphql.language/System.Diagnostics.CodeAnalysis/NullableAttributes.cs
+++ b/src/graphql.language/System.Diagnostics.CodeAnalysis/NullableAttributes.cs
@@ -1,0 +1,197 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Diagnostics.CodeAnalysis
+{
+// These attributes already shipped with .NET Core 3.1 in System.Runtime
+#if !NETCOREAPP3_0 && !NETCOREAPP3_1 && !NETSTANDARD2_1
+    /// <summary>Specifies that null is allowed as an input even if the corresponding type disallows it.</summary>
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property, Inherited = false)]
+#if SYSTEM_PRIVATE_CORELIB
+    public
+#else
+    internal
+#endif
+        sealed class AllowNullAttribute : Attribute { }
+
+    /// <summary>Specifies that null is disallowed as an input even if the corresponding type allows it.</summary>
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property, Inherited = false)]
+#if SYSTEM_PRIVATE_CORELIB
+    public
+#else
+    internal
+#endif
+        sealed class DisallowNullAttribute : Attribute { }
+
+    /// <summary>Specifies that an output may be null even if the corresponding type disallows it.</summary>
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue, Inherited = false)]
+#if SYSTEM_PRIVATE_CORELIB
+    public
+#else
+    internal
+#endif
+        sealed class MaybeNullAttribute : Attribute { }
+
+    /// <summary>Specifies that an output will not be null even if the corresponding type allows it. Specifies that an input argument was not null when the call returns.</summary>
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue, Inherited = false)]
+#if SYSTEM_PRIVATE_CORELIB
+    public
+#else
+    internal
+#endif
+        sealed class NotNullAttribute : Attribute { }
+
+    /// <summary>Specifies that when a method returns <see cref="ReturnValue"/>, the parameter may be null even if the corresponding type disallows it.</summary>
+    [AttributeUsage(AttributeTargets.Parameter, Inherited = false)]
+#if SYSTEM_PRIVATE_CORELIB
+    public
+#else
+    internal
+#endif
+        sealed class MaybeNullWhenAttribute : Attribute
+    {
+        /// <summary>Initializes the attribute with the specified return value condition.</summary>
+        /// <param name="returnValue">
+        /// The return value condition. If the method returns this value, the associated parameter may be null.
+        /// </param>
+        public MaybeNullWhenAttribute(bool returnValue) => ReturnValue = returnValue;
+
+        /// <summary>Gets the return value condition.</summary>
+        public bool ReturnValue { get; }
+    }
+
+    /// <summary>Specifies that when a method returns <see cref="ReturnValue"/>, the parameter will not be null even if the corresponding type allows it.</summary>
+    [AttributeUsage(AttributeTargets.Parameter, Inherited = false)]
+#if SYSTEM_PRIVATE_CORELIB
+    public
+#else
+    internal
+#endif
+        sealed class NotNullWhenAttribute : Attribute
+    {
+        /// <summary>Initializes the attribute with the specified return value condition.</summary>
+        /// <param name="returnValue">
+        /// The return value condition. If the method returns this value, the associated parameter will not be null.
+        /// </param>
+        public NotNullWhenAttribute(bool returnValue) => ReturnValue = returnValue;
+
+        /// <summary>Gets the return value condition.</summary>
+        public bool ReturnValue { get; }
+    }
+
+    /// <summary>Specifies that the output will be non-null if the named parameter is non-null.</summary>
+    [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue, AllowMultiple = true, Inherited = false)]
+#if SYSTEM_PRIVATE_CORELIB
+    public
+#else
+    internal
+#endif
+        sealed class NotNullIfNotNullAttribute : Attribute
+    {
+        /// <summary>Initializes the attribute with the associated parameter name.</summary>
+        /// <param name="parameterName">
+        /// The associated parameter name.  The output will be non-null if the argument to the parameter specified is non-null.
+        /// </param>
+        public NotNullIfNotNullAttribute(string parameterName) => ParameterName = parameterName;
+
+        /// <summary>Gets the associated parameter name.</summary>
+        public string ParameterName { get; }
+    }
+
+    /// <summary>Applied to a method that will never return under any circumstance.</summary>
+    [AttributeUsage(AttributeTargets.Method, Inherited = false)]
+#if SYSTEM_PRIVATE_CORELIB
+    public
+#else
+    internal
+#endif
+        sealed class DoesNotReturnAttribute : Attribute { }
+
+    /// <summary>Specifies that the method will not return if the associated Boolean parameter is passed the specified value.</summary>
+    [AttributeUsage(AttributeTargets.Parameter, Inherited = false)]
+#if SYSTEM_PRIVATE_CORELIB
+    public
+#else
+    internal
+#endif
+        sealed class DoesNotReturnIfAttribute : Attribute
+    {
+        /// <summary>Initializes the attribute with the specified parameter value.</summary>
+        /// <param name="parameterValue">
+        /// The condition parameter value. Code after the method will be considered unreachable by diagnostics if the argument to
+        /// the associated parameter matches this value.
+        /// </param>
+        public DoesNotReturnIfAttribute(bool parameterValue) => ParameterValue = parameterValue;
+
+        /// <summary>Gets the condition parameter value.</summary>
+        public bool ParameterValue { get; }
+    }
+#endif
+
+    /// <summary>Specifies that the method or property will ensure that the listed field and property members have not-null values.</summary>
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Property, Inherited = false, AllowMultiple = true)]
+#if SYSTEM_PRIVATE_CORELIB
+    public
+#else
+    internal
+#endif
+        sealed class MemberNotNullAttribute : Attribute
+    {
+        /// <summary>Initializes the attribute with a field or property member.</summary>
+        /// <param name="member">
+        /// The field or property member that is promised to be not-null.
+        /// </param>
+        public MemberNotNullAttribute(string member) => Members = new[] { member };
+
+        /// <summary>Initializes the attribute with the list of field and property members.</summary>
+        /// <param name="members">
+        /// The list of field and property members that are promised to be not-null.
+        /// </param>
+        public MemberNotNullAttribute(params string[] members) => Members = members;
+
+        /// <summary>Gets field or property member names.</summary>
+        public string[] Members { get; }
+    }
+
+    /// <summary>Specifies that the method or property will ensure that the listed field and property members have not-null values when returning with the specified return value condition.</summary>
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Property, Inherited = false, AllowMultiple = true)]
+#if SYSTEM_PRIVATE_CORELIB
+    public
+#else
+    internal
+#endif
+        sealed class MemberNotNullWhenAttribute : Attribute
+    {
+        /// <summary>Initializes the attribute with the specified return value condition and a field or property member.</summary>
+        /// <param name="returnValue">
+        /// The return value condition. If the method returns this value, the associated parameter will not be null.
+        /// </param>
+        /// <param name="member">
+        /// The field or property member that is promised to be not-null.
+        /// </param>
+        public MemberNotNullWhenAttribute(bool returnValue, string member)
+        {
+            ReturnValue = returnValue;
+            Members = new[] { member };
+        }
+
+        /// <summary>Initializes the attribute with the specified return value condition and list of field and property members.</summary>
+        /// <param name="returnValue">
+        /// The return value condition. If the method returns this value, the associated parameter will not be null.
+        /// </param>
+        /// <param name="members">
+        /// The list of field and property members that are promised to be not-null.
+        /// </param>
+        public MemberNotNullWhenAttribute(bool returnValue, params string[] members)
+        {
+            ReturnValue = returnValue;
+            Members = members;
+        }
+
+        /// <summary>Gets the return value condition.</summary>
+        public bool ReturnValue { get; }
+
+        /// <summary>Gets field or property member names.</summary>
+        public string[] Members { get; }
+    }
+}

--- a/src/graphql.language/graphql.language.csproj
+++ b/src/graphql.language/graphql.language.csproj
@@ -1,11 +1,20 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <AssemblyName>tanka.graphql.language</AssemblyName>
     <RootNamespace>Tanka.GraphQL.Language</RootNamespace>
     <Nullable>enable</Nullable>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <PackageReference Include="System.Memory" Version="4.5.4" />
+    <PackageReference Include="Microsoft.Bcl.HashCode" Version="1.1.1" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
+    <Compile Remove="Shims/**" />
+    <Compile Remove="System.Diagnostics.CodeAnalysis/**" />
+  </ItemGroup>
 </Project>

--- a/src/graphql.server.links/IntrospectionParser.cs
+++ b/src/graphql.server.links/IntrospectionParser.cs
@@ -21,7 +21,6 @@ public static class IntrospectionParser
     public static IntrospectionResult Deserialize(
         string introspectionResult)
     {
-        //todo: this is awkward
         var bytes = Encoding.UTF8.GetBytes(introspectionResult);
 
         var result = JsonSerializer

--- a/src/graphql.server/Utils/CancellationTokenExtensions.cs
+++ b/src/graphql.server/Utils/CancellationTokenExtensions.cs
@@ -21,7 +21,7 @@ internal static class CancellationTokenExtensions
 
         var taskCompletionSource = new TaskCompletionSource<bool>();
 
-        using (cancellationToken.Register(() => { taskCompletionSource.TrySetResult(true); }))
+        await using (cancellationToken.Register(() => { taskCompletionSource.TrySetResult(true); }))
         {
             await taskCompletionSource.Task;
         }

--- a/src/graphql.server/WebSockets/GraphQLWSProtocol.cs
+++ b/src/graphql.server/WebSockets/GraphQLWSProtocol.cs
@@ -34,7 +34,7 @@ public class GraphQLWSProtocol : IProtocolHandler
         _parserOptions = new ParserOptions
         {
             ImportProviders = null
-        }; //todo: inject
+        };
     }
 
     protected ConcurrentDictionary<string, Subscription> Subscriptions { get; } = new();

--- a/src/graphql/Directives/DirectiveFieldVisitorContext.cs
+++ b/src/graphql/Directives/DirectiveFieldVisitorContext.cs
@@ -4,42 +4,27 @@ using Tanka.GraphQL.ValueResolution;
 
 namespace Tanka.GraphQL.Directives;
 
-public class DirectiveFieldVisitorContext : IEquatable<DirectiveFieldVisitorContext>
+public record DirectiveFieldVisitorContext(
+    FieldDefinition Field,
+    Resolver? Resolver,
+    Subscriber? Subscriber)
 {
-    public DirectiveFieldVisitorContext(
-        FieldDefinition value,
-        Resolver resolver,
-        Subscriber subscriber)
-    {
-        Field = value;
-        Resolver = resolver;
-        Subscriber = subscriber;
-    }
-
-    public FieldDefinition Field { get; }
-
-    public Resolver Resolver { get; }
-
-    public Subscriber Subscriber { get; }
-
-    public bool Equals(DirectiveFieldVisitorContext? other)
-    {
-        if (ReferenceEquals(null, other)) return false;
-        if (ReferenceEquals(this, other)) return true;
-        return Field.Equals(other.Field) && Resolver.Equals(other.Resolver) && Subscriber.Equals(other.Subscriber);
-    }
-
-    public DirectiveFieldVisitorContext WithResolver(Action<ResolverBuilder> build)
+    public DirectiveFieldVisitorContext WithResolver(
+        Action<ResolverBuilder> build)
     {
         if (build == null) throw new ArgumentNullException(nameof(build));
 
         var builder = new ResolverBuilder();
         build(builder);
 
-        return new DirectiveFieldVisitorContext(Field, builder.Build(), Subscriber);
+        return this with
+        {
+            Resolver = builder.Build()
+        };
     }
 
-    public DirectiveFieldVisitorContext WithSubscriber(Action<ResolverBuilder> buildResolver,
+    public DirectiveFieldVisitorContext WithSubscriber(
+        Action<ResolverBuilder> buildResolver,
         Action<SubscriberBuilder> buildSubscriber)
     {
         if (buildResolver == null) throw new ArgumentNullException(nameof(buildResolver));
@@ -51,29 +36,10 @@ public class DirectiveFieldVisitorContext : IEquatable<DirectiveFieldVisitorCont
         var subscriberBuilder = new SubscriberBuilder();
         buildSubscriber(subscriberBuilder);
 
-        return new DirectiveFieldVisitorContext(Field, resolverBuilder.Build(), subscriberBuilder.Build());
-    }
-
-    public override bool Equals(object? obj)
-    {
-        if (ReferenceEquals(null, obj)) return false;
-        if (ReferenceEquals(this, obj)) return true;
-        if (obj.GetType() != GetType()) return false;
-        return Equals((DirectiveFieldVisitorContext)obj);
-    }
-
-    public override int GetHashCode()
-    {
-        return HashCode.Combine(Field, Resolver, Subscriber);
-    }
-
-    public static bool operator ==(DirectiveFieldVisitorContext? left, DirectiveFieldVisitorContext? right)
-    {
-        return Equals(left, right);
-    }
-
-    public static bool operator !=(DirectiveFieldVisitorContext? left, DirectiveFieldVisitorContext? right)
-    {
-        return !Equals(left, right);
+        return this with
+        {
+            Resolver = resolverBuilder.Build(),
+            Subscriber = subscriberBuilder.Build()
+        };
     }
 }

--- a/src/graphql/Execution/SelectionSets.cs
+++ b/src/graphql/Execution/SelectionSets.cs
@@ -10,6 +10,9 @@ namespace Tanka.GraphQL.Execution;
 
 public static class SelectionSets
 {
+    public const string SkipDirectiveName = "skip";
+    public const string IncludeDirectiveName = "include";
+
     public static async Task<IDictionary<string, object>?> ExecuteSelectionSetAsync(
         IExecutorContext executorContext,
         SelectionSet selectionSet,
@@ -70,11 +73,11 @@ public static class SelectionSets
         {
             var directives = GetDirectives(selection).ToList();
 
-            var skipDirective = directives.FirstOrDefault(d => d.Name == "skip"); //todo: skip to constant
+            var skipDirective = directives.FirstOrDefault(d => d.Name == SkipDirectiveName);
             if (SkipSelection(skipDirective, coercedVariableValues, schema, objectDefinition, selection))
                 continue;
 
-            var includeDirective = directives.FirstOrDefault(d => d.Name == "include"); //todo: include to constant
+            var includeDirective = directives.FirstOrDefault(d => d.Name == IncludeDirectiveName);
             if (!IncludeSelection(includeDirective, coercedVariableValues, schema, objectDefinition, selection))
                 continue;
 
@@ -168,7 +171,7 @@ public static class SelectionSets
         if (includeDirective?.Arguments == null)
             return true;
 
-        var ifArgument = includeDirective.Arguments.SingleOrDefault(a => a.Name == "if"); //todo: if to constants
+        var ifArgument = includeDirective.Arguments.SingleOrDefault(a => a.Name == "if");
         return GetIfArgumentValue(schema, includeDirective, coercedVariableValues, ifArgument);
     }
 
@@ -182,7 +185,7 @@ public static class SelectionSets
         if (skipDirective?.Arguments == null)
             return false;
 
-        var ifArgument = skipDirective.Arguments.SingleOrDefault(a => a.Name == "if"); //todo: if to constants
+        var ifArgument = skipDirective.Arguments.SingleOrDefault(a => a.Name == "if");
         return GetIfArgumentValue(schema, skipDirective, coercedVariableValues, ifArgument);
     }
 

--- a/src/graphql/Execution/Values.cs
+++ b/src/graphql/Execution/Values.cs
@@ -154,7 +154,7 @@ public static class Values
         var coercedListValues = new List<object?>();
         if (value is ListValue listValue)
         {
-            foreach (var listValueValue in listValue.Values)
+            foreach (var listValueValue in listValue)
             {
                 var coercedValue = CoerceValue(schema, listValueValue,
                     listWrappedType);

--- a/src/graphql/FieldResolversMap.cs
+++ b/src/graphql/FieldResolversMap.cs
@@ -111,4 +111,24 @@ public class FieldResolversMap : IEnumerable<Resolver>, IEnumerable<Subscriber>
 
         return result;
     }
+
+    public void Replace(string fieldName, Resolver resolver)
+    {
+        _resolvers[fieldName] = resolver;
+    }
+
+    public void Replace(string fieldName, Subscriber subscriber)
+    {
+        _subscribers[fieldName] = subscriber;
+    }
+
+    public void RemoveResolver(string fieldName)
+    {
+        _resolvers.Remove(fieldName);
+    }
+
+    public void RemoveSubscriber(string fieldName)
+    {
+        _subscribers.Remove(fieldName);
+    }
 }

--- a/src/graphql/IExecutorExtension.cs
+++ b/src/graphql/IExecutorExtension.cs
@@ -4,6 +4,5 @@ namespace Tanka.GraphQL;
 
 public interface IExecutorExtension
 {
-    //todo: change to ValueTask ?
     Task<IExtensionScope> BeginExecuteAsync(ExecutionOptions options);
 }

--- a/src/graphql/Language/Visitor.cs
+++ b/src/graphql/Language/Visitor.cs
@@ -262,7 +262,7 @@ public class Visitor
 
     public virtual ListValue BeginVisitListValue(ListValue node)
     {
-        foreach (var node1 in node.Values)
+        foreach (var node1 in node)
             BeginVisitNode(node1);
 
         return EndVisitListValue(node);

--- a/src/graphql/ResolversMap.cs
+++ b/src/graphql/ResolversMap.cs
@@ -82,6 +82,54 @@ public class ResolversMap : Dictionary<string, FieldResolversMap>, IResolverMap,
         return true;
     }
 
+    public void Replace(string typeName, string fieldName, Resolver resolver)
+    {
+        if (!TryGetValue(typeName, out var fieldsResolvers)) 
+            fieldsResolvers = this[typeName] = new FieldResolversMap();
+
+        if (fieldsResolvers.GetResolver(fieldName) is not null)
+        {
+            fieldsResolvers.Replace(fieldName, resolver);
+        }
+        else
+            fieldsResolvers.Add(fieldName, resolver);
+    }
+
+    public void Replace(string typeName, string fieldName, Subscriber subscriber)
+    {
+        if (!TryGetValue(typeName, out var fieldsResolvers)) 
+            fieldsResolvers = this[typeName] = new FieldResolversMap();
+
+        if (fieldsResolvers.GetSubscriber(fieldName) is not null)
+        {
+            fieldsResolvers.Replace(fieldName, subscriber);
+        }
+        else
+            fieldsResolvers.Add(fieldName, subscriber);
+    }
+
+    public void RemoveResolver(string typeName, string fieldName)
+    {
+        if (!TryGetValue(typeName, out var fieldsResolvers))
+            return;
+
+        if (fieldsResolvers.GetResolver(fieldName) is not null)
+        {
+            fieldsResolvers.RemoveResolver(fieldName);
+        }
+    }
+
+    public void RemoveSubscriber(string typeName, string fieldName)
+    {
+        if (!TryGetValue(typeName, out var fieldsResolvers))
+            return;
+
+        if (fieldsResolvers.GetSubscriber(fieldName) is not null)
+        {
+            fieldsResolvers.RemoveSubscriber(fieldName);
+        }
+    }
+
     public ResolversMap Clone()
     {
         var result = new ResolversMap();

--- a/src/graphql/Validation/ExecutionRules.cs
+++ b/src/graphql/Validation/ExecutionRules.cs
@@ -173,7 +173,6 @@ public static class ExecutionRules
                     return;
 
                 var schema = context.Schema;
-                //todo(pekka): should this report error?
                 if (schema.Subscription == null)
                     return;
 
@@ -213,7 +212,7 @@ public static class ExecutionRules
             {
                 var fieldName = selection.Name;
 
-                if (fieldName == "__typename") //todo: to constant
+                if (fieldName == "__typename")
                     return;
 
                 if (context.Tracker.FieldDefinition == null)
@@ -261,7 +260,7 @@ public static class ExecutionRules
             {
                 var fieldName = selection.Name;
 
-                if (fieldName == "__typename") //todo: to constant
+                if (fieldName == "__typename")
                     return;
 
                 var field = context.Tracker.FieldDefinition;
@@ -856,7 +855,6 @@ public static class ExecutionRules
     {
         return (context, rule) =>
         {
-            //todo: there's an objectkind for nullvalue but no type
             //rule.EnterNullValue += node => { };
 
             rule.EnterListValue += node => { IsValidScalar(context, node); };

--- a/tests/graphql.language.tests/LineReaderFacts.cs
+++ b/tests/graphql.language.tests/LineReaderFacts.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Text;
 using Tanka.GraphQL.Language.Internal;
 using Xunit;

--- a/tests/graphql.language.tests/ParserFacts.cs
+++ b/tests/graphql.language.tests/ParserFacts.cs
@@ -826,7 +826,7 @@ Description
 
         /* Then */
         var listValue = Assert.IsType<ListValue>(value);
-        Assert.Equal(0, listValue.Values.Count);
+        Assert.Equal(0, listValue.Count);
     }
 
     [Fact]
@@ -840,8 +840,8 @@ Description
 
         /* Then */
         var listValue = Assert.IsType<ListValue>(value);
-        Assert.Equal(3, listValue.Values.Count);
-        Assert.All(listValue.Values, v => Assert.IsType<IntValue>(v));
+        Assert.Equal(3, listValue.Count);
+        Assert.All(listValue, v => Assert.IsType<IntValue>(v));
     }
 
     [Fact]

--- a/tests/graphql.language.tests/graphql.language.tests.csproj
+++ b/tests/graphql.language.tests/graphql.language.tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;netcoreapp3.1</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <AssemblyName>tanka.graphql.language.tests</AssemblyName>
     <RootNamespace>Tanka.GraphQL.Language.Tests</RootNamespace>

--- a/tests/graphql.language.tests/graphql.language.tests.csproj
+++ b/tests/graphql.language.tests/graphql.language.tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <AssemblyName>tanka.graphql.language.tests</AssemblyName>
     <RootNamespace>Tanka.GraphQL.Language.Tests</RootNamespace>
@@ -34,5 +34,4 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\graphql.language\graphql.language.csproj" />
   </ItemGroup>
-
 </Project>

--- a/tests/graphql.server.tests/Usages/ServerBuilderUsageFacts.cs
+++ b/tests/graphql.server.tests/Usages/ServerBuilderUsageFacts.cs
@@ -187,7 +187,7 @@ public class ServerBuilderUsageFacts
             .ConfigureWebSockets(async context =>
             {
                 called = true;
-                var succeeded = true; //todo: authorize
+                var succeeded = true; //authorize
 
                 if (succeeded)
                 {

--- a/tests/graphql.tests/Introspection/IntrospectSchemaFacts.cs
+++ b/tests/graphql.tests/Introspection/IntrospectSchemaFacts.cs
@@ -310,7 +310,6 @@ type Subscription {}
     public async Task Type_EnumType()
     {
         /* Given */
-        //todo(pekka): separate enumValues testing to own test
         var query = @"{ 
                             __type(name: ""Enum"") {
                                 kind

--- a/tests/graphql.tests/TypeSystem/SchemaBuilderFacts.cs
+++ b/tests/graphql.tests/TypeSystem/SchemaBuilderFacts.cs
@@ -1,0 +1,5 @@
+﻿namespace Tanka.GraphQL.Tests.TypeSystem;
+
+public class SchemaBuilderFacts
+{
+}

--- a/tests/graphql.tests/graphql.tests.csproj
+++ b/tests/graphql.tests/graphql.tests.csproj
@@ -6,9 +6,8 @@
     <AssemblyName>tanka.graphql.tests</AssemblyName>
     <RootNamespace>Tanka.GraphQL.Tests</RootNamespace>
   </PropertyGroup>
-
- <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+  <ItemGroup>
+   <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="NSubstitute" Version="4.3.0" />
     <PackageReference Include="System.Text.Json" Version="6.0.2" />

--- a/tutorials/graphql.tutorials.getting-started/GettingStarted.cs
+++ b/tutorials/graphql.tutorials.getting-started/GettingStarted.cs
@@ -82,7 +82,7 @@ public class GettingStarted
         Assert.Equal("Test", nameValue.Value);
     }
 
-    [Fact(Skip = "todo: modifying resolvers")]
+    [Fact]
     public async Task Part3_ApplyDirectives_on_Object_fields()
     {
         // Create builder, load sdl with our types


### PR DESCRIPTION
+ Resolvers and subsribers can be changed/replaced/removed
+ Make language module netstandard2.0 compatible (Roslyn source generators work on netstandard2.0)