### PR TITLE
feat: upgrade target framework from .NET 8.0 to .NET 9.0

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,6 +29,7 @@ jobs:
             6.0.x
             7.0.x
             8.0.x
+            9.0.x
 
       - name: Build docs
         shell: pwsh

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -33,6 +33,7 @@ jobs:
             6.0.x
             7.0.x
             8.0.x
+            9.0.x
       
       - name: Build packages
         shell: pwsh

--- a/.github/workflows/on-tag-do-release.yml
+++ b/.github/workflows/on-tag-do-release.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: 9.0.x
 
       - name: Run
         run: |

--- a/benchmarks/GraphQL.Benchmarks/GraphQL.Benchmarks.csproj
+++ b/benchmarks/GraphQL.Benchmarks/GraphQL.Benchmarks.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
 	  <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/dev/GraphQL.Dev.Allocations/GraphQL.Dev.Allocations.csproj
+++ b/dev/GraphQL.Dev.Allocations/GraphQL.Dev.Allocations.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/dev/GraphQL.Dev.Reviews/GraphQL.Dev.Reviews.csproj
+++ b/dev/GraphQL.Dev.Reviews/GraphQL.Dev.Reviews.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/GraphQL.Samples.Authorization/GraphQL.Samples.Authorization.csproj
+++ b/samples/GraphQL.Samples.Authorization/GraphQL.Samples.Authorization.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/samples/GraphQL.Samples.Http/GraphQL.Samples.Http.csproj
+++ b/samples/GraphQL.Samples.Http/GraphQL.Samples.Http.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/samples/GraphQL.Samples.SG.Arguments/GraphQL.Samples.SG.Arguments.csproj
+++ b/samples/GraphQL.Samples.SG.Arguments/GraphQL.Samples.SG.Arguments.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/samples/GraphQL.Samples.SG.Basic/GraphQL.Samples.SG.Basic.csproj
+++ b/samples/GraphQL.Samples.SG.Basic/GraphQL.Samples.SG.Basic.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/samples/GraphQL.Samples.SG.InputType/GraphQL.Samples.SG.InputType.csproj
+++ b/samples/GraphQL.Samples.SG.InputType/GraphQL.Samples.SG.InputType.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/samples/GraphQL.Samples.SG.Namespace/GraphQL.Samples.SG.Namespace.csproj
+++ b/samples/GraphQL.Samples.SG.Namespace/GraphQL.Samples.SG.Namespace.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/samples/GraphQL.Samples.SG.Services/GraphQL.Samples.SG.Services.csproj
+++ b/samples/GraphQL.Samples.SG.Services/GraphQL.Samples.SG.Services.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/samples/GraphQL.Samples.SG.Subscription/GraphQL.Samples.SG.Subscription.csproj
+++ b/samples/GraphQL.Samples.SG.Subscription/GraphQL.Samples.SG.Subscription.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/src/GraphQL.Extensions.ApolloFederation/GraphQL.Extensions.ApolloFederation.csproj
+++ b/src/GraphQL.Extensions.ApolloFederation/GraphQL.Extensions.ApolloFederation.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net8.0</TargetFrameworks>
+		<TargetFrameworks>net9.0</TargetFrameworks>
 		<Nullable>enable</Nullable>
 	</PropertyGroup>
 

--- a/src/GraphQL.Extensions.Experimental/GraphQL.Extensions.Experimental.csproj
+++ b/src/GraphQL.Extensions.Experimental/GraphQL.Extensions.Experimental.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <IsPackable>true</IsPackable>

--- a/src/GraphQL.Extensions.Tracing/GraphQL.Extensions.Tracing.csproj
+++ b/src/GraphQL.Extensions.Tracing/GraphQL.Extensions.Tracing.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/GraphQL.Language/GraphQL.Language.csproj
+++ b/src/GraphQL.Language/GraphQL.Language.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net8.0;netstandard2.0</TargetFrameworks>
+        <TargetFrameworks>net9.0;netstandard2.0</TargetFrameworks>
         <Nullable>enable</Nullable>
         <LangVersion>12</LangVersion>
         <IsPackable>true</IsPackable>
@@ -12,7 +12,7 @@
         <PackageReference Include="Microsoft.Bcl.HashCode" Version="1.1.1" />
     </ItemGroup>
 
-    <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
+    <ItemGroup Condition=" '$(TargetFramework)' == 'net9.0' ">
         <Compile Remove="Shims/**" />
         <Compile Remove="System.Diagnostics.CodeAnalysis/**" />
     </ItemGroup>

--- a/src/GraphQL.Server.SourceGenerators/GraphQL.Server.SourceGenerators.csproj
+++ b/src/GraphQL.Server.SourceGenerators/GraphQL.Server.SourceGenerators.csproj
@@ -27,7 +27,7 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.11.0" PrivateAssets="all" />
         <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0" PrivateAssets="all" />
-        <PackageReference Include="System.Text.Json" Version="8.0.5" PrivateAssets="all" GeneratePathProperty="true" />
+        <PackageReference Include="System.Text.Json" Version="9.0.0" PrivateAssets="all" GeneratePathProperty="true" />
         <PackageReference Include="Scriban" Version="5.10.0" IncludeAssets="Build" />
         <PackageReference Include="Microsoft.CSharp" Version="4.7.0" PrivateAssets="all" />
         <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" PrivateAssets="all" />

--- a/src/GraphQL.Server/GraphQL.Server.csproj
+++ b/src/GraphQL.Server/GraphQL.Server.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net9.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 	</PropertyGroup>

--- a/src/GraphQL.Server/GraphQL.Server.csproj
+++ b/src/GraphQL.Server/GraphQL.Server.csproj
@@ -16,9 +16,9 @@
 
 	<ItemGroup>
 		<FrameworkReference Include="Microsoft.AspNetCore.App" />
-		<PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
-		<PackageReference Include="Microsoft.Extensions.Telemetry" Version="8.10.0" />
-		<PackageReference Include="System.IO.Pipelines" Version="8.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Options" Version="9.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Telemetry" Version="9.0.0" />
+		<PackageReference Include="System.IO.Pipelines" Version="9.0.0" />
 		<PackageReference Include="System.Net.WebSockets" Version="4.3.0" />
 	</ItemGroup>
 

--- a/src/GraphQL/GraphQL.csproj
+++ b/src/GraphQL/GraphQL.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net8.0</TargetFrameworks>
+		<TargetFrameworks>net9.0</TargetFrameworks>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 	</PropertyGroup>

--- a/src/GraphQL/GraphQL.csproj
+++ b/src/GraphQL/GraphQL.csproj
@@ -11,8 +11,8 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.Features" Version="8.0.10" />
-		<PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.1" />
-		<PackageReference Include="System.Text.Json" Version="8.0.5" />
+		<PackageReference Include="Microsoft.Extensions.Features" Version="9.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.0" />
+		<PackageReference Include="System.Text.Json" Version="9.0.0" />
 	</ItemGroup>
 </Project>

--- a/tests/GraphQL.Extensions.ApolloFederation.Tests/GraphQL.Extensions.ApolloFederation.Tests.csproj
+++ b/tests/GraphQL.Extensions.ApolloFederation.Tests/GraphQL.Extensions.ApolloFederation.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net9.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/tests/GraphQL.Extensions.Experimental.Tests/GraphQL.Extensions.Experimental.Tests.csproj
+++ b/tests/GraphQL.Extensions.Experimental.Tests/GraphQL.Extensions.Experimental.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/tests/GraphQL.Extensions.Tracing.Tests/GraphQL.Extensions.Tracing.Tests.csproj
+++ b/tests/GraphQL.Extensions.Tracing.Tests/GraphQL.Extensions.Tracing.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/tests/GraphQL.Language.Tests/GraphQL.Language.Tests.csproj
+++ b/tests/GraphQL.Language.Tests/GraphQL.Language.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net9.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
 	  <Nullabl>enable</Nullabl>
   </PropertyGroup>

--- a/tests/GraphQL.Server.SourceGenerators.Tests/GraphQL.Server.SourceGenerators.Tests.csproj
+++ b/tests/GraphQL.Server.SourceGenerators.Tests/GraphQL.Server.SourceGenerators.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net9.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>

--- a/tests/GraphQL.Server.Tests/GraphQL.Server.Tests.csproj
+++ b/tests/GraphQL.Server.Tests/GraphQL.Server.Tests.csproj
@@ -18,7 +18,7 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.10" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/tests/GraphQL.Server.Tests/GraphQL.Server.Tests.csproj
+++ b/tests/GraphQL.Server.Tests/GraphQL.Server.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFrameworks>net8.0</TargetFrameworks>
+        <TargetFrameworks>net9.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 

--- a/tests/GraphQL.Tests.Data/GraphQL.Mock.Data.csproj
+++ b/tests/GraphQL.Tests.Data/GraphQL.Mock.Data.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net9.0</TargetFrameworks>
 	  <IsPackable>false</IsPackable>
     <IsTestProject>false</IsTestProject>
   </PropertyGroup>

--- a/tests/GraphQL.Tests/GraphQL.Tests.csproj
+++ b/tests/GraphQL.Tests/GraphQL.Tests.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
-    <PackageReference Include="System.Text.Json" Version="8.0.5" />
+    <PackageReference Include="System.Text.Json" Version="9.0.0" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
       <PrivateAssets>all</PrivateAssets>

--- a/tests/GraphQL.Tests/GraphQL.Tests.csproj
+++ b/tests/GraphQL.Tests/GraphQL.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net9.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
 	  <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/tutorials/GraphQL.Tutorials.Getting-Started/GraphQL.Tutorials.GettingStarted.csproj
+++ b/tutorials/GraphQL.Tutorials.Getting-Started/GraphQL.Tutorials.GettingStarted.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net9.0</TargetFrameworks>
 	  <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/tutorials/GraphQL.Tutorials.Getting-Started/GraphQL.Tutorials.GettingStarted.csproj
+++ b/tutorials/GraphQL.Tutorials.Getting-Started/GraphQL.Tutorials.GettingStarted.csproj
@@ -14,8 +14,8 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.10" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Resolves #1967

Updates all project files to target .NET 9.0 while preserving:
- netstandard2.0 targets for backward compatibility
- Source generators remain at netstandard2.0 as specified

Updated 26 project files across:
- Core libraries (6 projects)
- Test projects (8 projects) 
- Sample projects (8 projects)
- Development/benchmarks (3 projects)
- Tutorials (1 project)

Generated with [Claude Code](https://claude.ai/code)