### PR TITLE
feat: Add comprehensive schema validation infrastructure with @oneOf RFC compliance

### DIFF
--- a/src/GraphQL/Introspection/IntrospectionResolvers.cs
+++ b/src/GraphQL/Introspection/IntrospectionResolvers.cs
@@ -150,6 +150,16 @@ public class IntrospectionResolvers : ResolversMap
                     ListType list => list.OfType,
                     _ => null
                 })
+            },
+
+            // INPUT_OBJECT only - @oneOf directive support
+            {
+                "isOneOf", context => context.ResolveAsPropertyOf<INode>(t => t switch
+                {
+                    null => null,
+                    InputObjectDefinition inputObjectDefinition => inputObjectDefinition.HasDirective("oneOf"),
+                    _ => null
+                })
             }
         };
 

--- a/src/GraphQL/Introspection/IntrospectionSchema.cs
+++ b/src/GraphQL/Introspection/IntrospectionSchema.cs
@@ -41,6 +41,8 @@ type __Type {
   ofType: __Type
   # may be non-null for custom SCALAR, otherwise null.
   specifiedByURL: String
+  # must be non-null for INPUT_OBJECT, otherwise null.
+  isOneOf: Boolean
 }
 
 enum __TypeKind {

--- a/src/GraphQL/TypeSystem/SchemaBuildOptions.cs
+++ b/src/GraphQL/TypeSystem/SchemaBuildOptions.cs
@@ -1,4 +1,5 @@
 ﻿using Tanka.GraphQL.Directives;
+using Tanka.GraphQL.TypeSystem.SchemaValidation;
 using Tanka.GraphQL.ValueResolution;
 using Tanka.GraphQL.ValueSerialization;
 
@@ -33,6 +34,8 @@ public record SchemaBuildOptions
     public IResolverMap? Resolvers { get; set; }
 
     public ISubscriberMap? Subscribers { get; set; }
+
+    public IEnumerable<SchemaValidationRule>? SchemaValidationRules { get; set; } = BuiltInSchemaValidationRules.All;
 
     public IReadOnlyDictionary<string, IValueConverter>? ValueConverters { get; set; } =
         new Dictionary<string, IValueConverter>

--- a/src/GraphQL/TypeSystem/SchemaValidation/BuiltInSchemaValidationRules.cs
+++ b/src/GraphQL/TypeSystem/SchemaValidation/BuiltInSchemaValidationRules.cs
@@ -4,8 +4,7 @@ namespace Tanka.GraphQL.TypeSystem.SchemaValidation;
 
 public static class BuiltInSchemaValidationRules
 {
-    public static IEnumerable<SchemaValidationRule> All => new SchemaValidationRule[]
-    {
-        new OneOfInputObjectRule()
-    };
+    private static readonly SchemaValidationRule[] _allRules = [new OneOfInputObjectRule()];
+
+    public static IEnumerable<SchemaValidationRule> All => _allRules;
 }

--- a/src/GraphQL/TypeSystem/SchemaValidation/BuiltInSchemaValidationRules.cs
+++ b/src/GraphQL/TypeSystem/SchemaValidation/BuiltInSchemaValidationRules.cs
@@ -1,0 +1,11 @@
+using Tanka.GraphQL.TypeSystem.SchemaValidation.Rules;
+
+namespace Tanka.GraphQL.TypeSystem.SchemaValidation;
+
+public static class BuiltInSchemaValidationRules
+{
+    public static IEnumerable<SchemaValidationRule> All => new SchemaValidationRule[]
+    {
+        new OneOfInputObjectRule()
+    };
+}

--- a/src/GraphQL/TypeSystem/SchemaValidation/ISchemaValidator.cs
+++ b/src/GraphQL/TypeSystem/SchemaValidation/ISchemaValidator.cs
@@ -1,0 +1,8 @@
+using Tanka.GraphQL.Language.Nodes.TypeSystem;
+
+namespace Tanka.GraphQL.TypeSystem.SchemaValidation;
+
+public interface ISchemaValidator
+{
+    SchemaValidationResult Validate(IEnumerable<TypeDefinition> typeDefinitions);
+}

--- a/src/GraphQL/TypeSystem/SchemaValidation/Rules/OneOfInputObjectRule.cs
+++ b/src/GraphQL/TypeSystem/SchemaValidation/Rules/OneOfInputObjectRule.cs
@@ -1,0 +1,36 @@
+using Tanka.GraphQL.Language;
+using Tanka.GraphQL.Language.Nodes.TypeSystem;
+
+namespace Tanka.GraphQL.TypeSystem.SchemaValidation.Rules;
+
+public class OneOfInputObjectRule : SchemaValidationRule
+{
+    public override void ValidateInputObjectDefinition(InputObjectDefinition inputObjectDefinition)
+    {
+        // Check if this input object has @oneOf directive
+        if (!inputObjectDefinition.HasDirective("oneOf"))
+            return;
+
+        // Validate that @oneOf input objects have at least one field
+        if (inputObjectDefinition.Fields is null || !inputObjectDefinition.Fields.Any())
+        {
+            ReportError(new SchemaValidationError(
+                SchemaValidationErrorCodes.OneOfInputObjectNoFields,
+                $"@oneOf input object '{inputObjectDefinition.Name}' must have at least one field",
+                inputObjectDefinition));
+            return;
+        }
+
+        // Validate that no fields have default values
+        foreach (var field in inputObjectDefinition.Fields)
+        {
+            if (field.DefaultValue != null)
+            {
+                ReportError(new SchemaValidationError(
+                    SchemaValidationErrorCodes.OneOfInputObjectDefaultValue,
+                    $"@oneOf input object '{inputObjectDefinition.Name}' field '{field.Name}' cannot have a default value. @oneOf input objects cannot have fields with default values",
+                    field));
+            }
+        }
+    }
+}

--- a/src/GraphQL/TypeSystem/SchemaValidation/SchemaValidationError.cs
+++ b/src/GraphQL/TypeSystem/SchemaValidation/SchemaValidationError.cs
@@ -1,0 +1,30 @@
+using Tanka.GraphQL.Language.Nodes;
+
+namespace Tanka.GraphQL.TypeSystem.SchemaValidation;
+
+public class SchemaValidationError
+{
+    public SchemaValidationError(string code, string message, INode? node = null)
+    {
+        Code = code;
+        Message = message;
+        Node = node;
+    }
+
+    public SchemaValidationError(string code, string message, IEnumerable<INode> nodes)
+    {
+        Code = code;
+        Message = message;
+        Nodes = nodes.ToList();
+    }
+
+    public string Code { get; }
+    public string Message { get; }
+    public INode? Node { get; }
+    public IReadOnlyList<INode>? Nodes { get; }
+
+    public override string ToString()
+    {
+        return $"{Code}: {Message}";
+    }
+}

--- a/src/GraphQL/TypeSystem/SchemaValidation/SchemaValidationErrorCodes.cs
+++ b/src/GraphQL/TypeSystem/SchemaValidation/SchemaValidationErrorCodes.cs
@@ -1,0 +1,7 @@
+namespace Tanka.GraphQL.TypeSystem.SchemaValidation;
+
+public static class SchemaValidationErrorCodes
+{
+    public const string OneOfInputObjectDefaultValue = "SCHEMA_ONEOF_001";
+    public const string OneOfInputObjectNoFields = "SCHEMA_ONEOF_002";
+}

--- a/src/GraphQL/TypeSystem/SchemaValidation/SchemaValidationException.cs
+++ b/src/GraphQL/TypeSystem/SchemaValidation/SchemaValidationException.cs
@@ -1,0 +1,24 @@
+namespace Tanka.GraphQL.TypeSystem.SchemaValidation;
+
+public class SchemaValidationException : Exception
+{
+    public SchemaValidationException(IEnumerable<SchemaValidationError> errors)
+        : base($"Schema validation failed with {errors.Count()} error(s)")
+    {
+        Errors = errors.ToList();
+    }
+
+    public SchemaValidationException(string message, IEnumerable<SchemaValidationError> errors)
+        : base(message)
+    {
+        Errors = errors.ToList();
+    }
+
+    public IReadOnlyList<SchemaValidationError> Errors { get; }
+
+    public override string ToString()
+    {
+        var errorMessages = string.Join("\n", Errors.Select(e => $"  - {e}"));
+        return $"{Message}\n{errorMessages}";
+    }
+}

--- a/src/GraphQL/TypeSystem/SchemaValidation/SchemaValidationResult.cs
+++ b/src/GraphQL/TypeSystem/SchemaValidation/SchemaValidationResult.cs
@@ -1,0 +1,35 @@
+namespace Tanka.GraphQL.TypeSystem.SchemaValidation;
+
+public class SchemaValidationResult
+{
+    public SchemaValidationResult()
+    {
+        Errors = new List<SchemaValidationError>();
+    }
+
+    public SchemaValidationResult(IEnumerable<SchemaValidationError> errors)
+    {
+        Errors = errors.ToList();
+    }
+
+    public IReadOnlyList<SchemaValidationError> Errors { get; }
+
+    public bool IsValid => !Errors.Any();
+
+    public void AddError(SchemaValidationError error)
+    {
+        if (Errors is List<SchemaValidationError> mutableErrors)
+        {
+            mutableErrors.Add(error);
+        }
+        else
+        {
+            throw new InvalidOperationException("Cannot add error to read-only result");
+        }
+    }
+
+    public void AddError(string code, string message)
+    {
+        AddError(new SchemaValidationError(code, message));
+    }
+}

--- a/src/GraphQL/TypeSystem/SchemaValidation/SchemaValidationRule.cs
+++ b/src/GraphQL/TypeSystem/SchemaValidation/SchemaValidationRule.cs
@@ -1,0 +1,23 @@
+using Tanka.GraphQL.Language.Nodes.TypeSystem;
+
+namespace Tanka.GraphQL.TypeSystem.SchemaValidation;
+
+public abstract class SchemaValidationRule
+{
+    protected Action<SchemaValidationError> ReportError { get; private set; } = _ => { };
+
+    internal void SetErrorReporter(Action<SchemaValidationError> reportError)
+    {
+        ReportError = reportError;
+    }
+
+    public virtual void ValidateTypeDefinition(TypeDefinition typeDefinition) { }
+    public virtual void ValidateObjectDefinition(ObjectDefinition objectDefinition) { }
+    public virtual void ValidateInterfaceDefinition(InterfaceDefinition interfaceDefinition) { }
+    public virtual void ValidateInputObjectDefinition(InputObjectDefinition inputObjectDefinition) { }
+    public virtual void ValidateUnionDefinition(UnionDefinition unionDefinition) { }
+    public virtual void ValidateEnumDefinition(EnumDefinition enumDefinition) { }
+    public virtual void ValidateScalarDefinition(ScalarDefinition scalarDefinition) { }
+    public virtual void ValidateFieldDefinition(FieldDefinition fieldDefinition, TypeDefinition parentType) { }
+    public virtual void ValidateInputValueDefinition(InputValueDefinition inputValueDefinition, TypeDefinition parentType) { }
+}

--- a/src/GraphQL/TypeSystem/SchemaValidation/SchemaValidator.cs
+++ b/src/GraphQL/TypeSystem/SchemaValidation/SchemaValidator.cs
@@ -1,0 +1,19 @@
+using Tanka.GraphQL.Language.Nodes.TypeSystem;
+
+namespace Tanka.GraphQL.TypeSystem.SchemaValidation;
+
+public class SchemaValidator : ISchemaValidator
+{
+    private readonly IEnumerable<SchemaValidationRule> _rules;
+
+    public SchemaValidator(IEnumerable<SchemaValidationRule> rules)
+    {
+        _rules = rules;
+    }
+
+    public SchemaValidationResult Validate(IEnumerable<TypeDefinition> typeDefinitions)
+    {
+        var walker = new SchemaWalker(_rules);
+        return walker.Walk(typeDefinitions);
+    }
+}

--- a/src/GraphQL/TypeSystem/SchemaValidation/SchemaWalker.cs
+++ b/src/GraphQL/TypeSystem/SchemaValidation/SchemaWalker.cs
@@ -1,0 +1,164 @@
+using Tanka.GraphQL.Language.Nodes.TypeSystem;
+
+namespace Tanka.GraphQL.TypeSystem.SchemaValidation;
+
+public class SchemaWalker
+{
+    private readonly List<SchemaValidationRule> _rules;
+    private readonly SchemaValidationResult _result;
+
+    public SchemaWalker(IEnumerable<SchemaValidationRule> rules)
+    {
+        _result = new SchemaValidationResult();
+        _rules = rules.ToList();
+        
+        // Set up error reporting for each rule
+        foreach (var rule in _rules)
+        {
+            rule.SetErrorReporter(error => _result.AddError(error));
+        }
+    }
+
+    public SchemaValidationResult Walk(IEnumerable<TypeDefinition> typeDefinitions)
+    {
+        foreach (var typeDefinition in typeDefinitions)
+        {
+            WalkTypeDefinition(typeDefinition);
+        }
+
+        return _result;
+    }
+
+    private void WalkTypeDefinition(TypeDefinition typeDefinition)
+    {
+        // Call general type definition validation
+        foreach (var rule in _rules)
+        {
+            rule.ValidateTypeDefinition(typeDefinition);
+        }
+
+        // Call specific type validation based on type
+        switch (typeDefinition)
+        {
+            case ObjectDefinition objectDefinition:
+                WalkObjectDefinition(objectDefinition);
+                break;
+            case InterfaceDefinition interfaceDefinition:
+                WalkInterfaceDefinition(interfaceDefinition);
+                break;
+            case InputObjectDefinition inputObjectDefinition:
+                WalkInputObjectDefinition(inputObjectDefinition);
+                break;
+            case UnionDefinition unionDefinition:
+                WalkUnionDefinition(unionDefinition);
+                break;
+            case EnumDefinition enumDefinition:
+                WalkEnumDefinition(enumDefinition);
+                break;
+            case ScalarDefinition scalarDefinition:
+                WalkScalarDefinition(scalarDefinition);
+                break;
+        }
+    }
+
+    private void WalkObjectDefinition(ObjectDefinition objectDefinition)
+    {
+        foreach (var rule in _rules)
+        {
+            rule.ValidateObjectDefinition(objectDefinition);
+        }
+
+        // Walk fields
+        if (objectDefinition.Fields != null)
+        {
+            foreach (var field in objectDefinition.Fields)
+            {
+                WalkFieldDefinition(field, objectDefinition);
+            }
+        }
+    }
+
+    private void WalkInterfaceDefinition(InterfaceDefinition interfaceDefinition)
+    {
+        foreach (var rule in _rules)
+        {
+            rule.ValidateInterfaceDefinition(interfaceDefinition);
+        }
+
+        // Walk fields
+        if (interfaceDefinition.Fields != null)
+        {
+            foreach (var field in interfaceDefinition.Fields)
+            {
+                WalkFieldDefinition(field, interfaceDefinition);
+            }
+        }
+    }
+
+    private void WalkInputObjectDefinition(InputObjectDefinition inputObjectDefinition)
+    {
+        foreach (var rule in _rules)
+        {
+            rule.ValidateInputObjectDefinition(inputObjectDefinition);
+        }
+
+        // Walk input fields
+        if (inputObjectDefinition.Fields != null)
+        {
+            foreach (var field in inputObjectDefinition.Fields)
+            {
+                WalkInputValueDefinition(field, inputObjectDefinition);
+            }
+        }
+    }
+
+    private void WalkUnionDefinition(UnionDefinition unionDefinition)
+    {
+        foreach (var rule in _rules)
+        {
+            rule.ValidateUnionDefinition(unionDefinition);
+        }
+    }
+
+    private void WalkEnumDefinition(EnumDefinition enumDefinition)
+    {
+        foreach (var rule in _rules)
+        {
+            rule.ValidateEnumDefinition(enumDefinition);
+        }
+    }
+
+    private void WalkScalarDefinition(ScalarDefinition scalarDefinition)
+    {
+        foreach (var rule in _rules)
+        {
+            rule.ValidateScalarDefinition(scalarDefinition);
+        }
+    }
+
+    private void WalkFieldDefinition(FieldDefinition fieldDefinition, TypeDefinition parentType)
+    {
+        foreach (var rule in _rules)
+        {
+            rule.ValidateFieldDefinition(fieldDefinition, parentType);
+        }
+
+        // Walk field arguments
+        if (fieldDefinition.Arguments != null)
+        {
+            foreach (var argument in fieldDefinition.Arguments)
+            {
+                WalkInputValueDefinition(argument, parentType);
+            }
+        }
+    }
+
+    private void WalkInputValueDefinition(InputValueDefinition inputValueDefinition, TypeDefinition parentType)
+    {
+        foreach (var rule in _rules)
+        {
+            rule.ValidateInputValueDefinition(inputValueDefinition, parentType);
+        }
+    }
+
+}

--- a/tests/GraphQL.Extensions.Experimental.Tests/OneOf/ValidationRuleFacts.cs
+++ b/tests/GraphQL.Extensions.Experimental.Tests/OneOf/ValidationRuleFacts.cs
@@ -1,6 +1,9 @@
-﻿using Tanka.GraphQL.Extensions.Experimental.OneOf;
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
 using Tanka.GraphQL.TypeSystem;
 using Tanka.GraphQL.Validation;
+using Xunit;
 
 namespace Tanka.GraphQL.Extensions.Experimental.Tests.OneOf;
 

--- a/tests/GraphQL.Language.Tests/ASTVisitorAndPrinterRobustnessFacts.cs
+++ b/tests/GraphQL.Language.Tests/ASTVisitorAndPrinterRobustnessFacts.cs
@@ -32,7 +32,7 @@ public class ASTVisitorAndPrinterRobustnessFacts
     {
         // Given: Document walker with null visitor in collection
         var document = Parser.Create("{ field }").ParseExecutableDocument();
-        var visitors = new List<IReadOnlyDocumentVisitor<PrinterContext>?> { null };
+        var visitors = new List<IReadOnlyDocumentVisitor<PrinterContext>?> { null! };
 
         // When & Then: Should handle null visitor gracefully
         var context = new PrinterContext();

--- a/tests/GraphQL.Language.Tests/PrinterFacts.cs
+++ b/tests/GraphQL.Language.Tests/PrinterFacts.cs
@@ -12,9 +12,9 @@ namespace Tanka.GraphQL.Language.Tests;
 public class PrinterFacts
 {
     [Theory]
-    [InlineData("name: [1,2,3]", "name", typeof(ListValue))]
-    [InlineData("another: -123.123", "another", typeof(FloatValue))]
-    public void Argument(string source, string argName, Type valueType)
+    [InlineData("name: [1,2,3]")]
+    [InlineData("another: -123.123")]
+    public void Argument(string source)
     {
         var node = Parser.Create(source)
             .ParseArgument();
@@ -57,9 +57,9 @@ public class PrinterFacts
     }
 
     [Theory]
-    [InlineData("123", 123)]
-    [InlineData("-123", -123)]
-    public void Value_Int(string source, int expectedValue)
+    [InlineData("123")]
+    [InlineData("-123")]
+    public void Value_Int(string source)
     {
         var node = Parser.Create(source)
             .ParseValue();
@@ -72,10 +72,10 @@ public class PrinterFacts
     }
 
     [Theory]
-    [InlineData("123.123", 123.123)]
-    [InlineData("-123.123", -123.123)]
-    [InlineData("123e20", 123e20)]
-    public void Value_Float(string source, double expectedValue)
+    [InlineData("123.123")]
+    [InlineData("-123.123")]
+    [InlineData("123e20")]
+    public void Value_Float(string source)
     {
         var node = Parser.Create(source)
             .ParseValue();
@@ -88,10 +88,10 @@ public class PrinterFacts
     }
 
     [Theory]
-    [InlineData("\"test\"", "test")]
-    [InlineData("\"test test\"", "test test")]
-    [InlineData("\"test_test\"", "test_test")]
-    public void Value_String(string source, string expectedValue)
+    [InlineData("\"test\"")]
+    [InlineData("\"test test\"")]
+    [InlineData("\"test_test\"")]
+    public void Value_String(string source)
     {
         var node = Parser.Create(source)
             .ParseValue();

--- a/tests/GraphQL.Tests/SchemaValidation/SchemaValidationInfrastructureFacts.cs
+++ b/tests/GraphQL.Tests/SchemaValidation/SchemaValidationInfrastructureFacts.cs
@@ -83,7 +83,7 @@ public class SchemaValidationInfrastructureFacts
             await builder.Build(new SchemaBuildOptions());
         });
 
-        Assert.Contains("must have at least one field", exception.Message);
         Assert.Single(exception.Errors);
+        Assert.Contains("must have at least one field", exception.Errors.First().Message);
     }
 }

--- a/tests/GraphQL.Tests/SchemaValidation/SchemaValidationInfrastructureFacts.cs
+++ b/tests/GraphQL.Tests/SchemaValidation/SchemaValidationInfrastructureFacts.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Tanka.GraphQL.TypeSystem;
+using Tanka.GraphQL.TypeSystem.SchemaValidation;
+using Xunit;
+
+namespace Tanka.GraphQL.Tests.SchemaValidation;
+
+public class SchemaValidationInfrastructureFacts
+{
+    [Fact]
+    public async Task Schema_validation_should_fail_for_oneOf_with_default_value()
+    {
+        // Given
+        var builder = new SchemaBuilder();
+        builder.Add(@"
+            input TestInput @oneOf {
+                field1: String = ""default""
+                field2: Int
+            }
+            
+            type Query {
+                test(input: TestInput): String
+            }
+        ");
+
+        // When & Then
+        var exception = await Assert.ThrowsAsync<SchemaValidationException>(async () =>
+        {
+            await builder.Build(new SchemaBuildOptions());
+        });
+
+        // Debug: Check the actual error message and error details
+        Assert.NotEmpty(exception.Errors);
+        var firstError = exception.Errors.First();
+        Assert.Contains("cannot have a default value", firstError.Message);
+        Assert.Single(exception.Errors);
+    }
+
+    [Fact]
+    public async Task Schema_validation_should_pass_for_valid_oneOf()
+    {
+        // Given
+        var builder = new SchemaBuilder();
+        builder.Add(@"
+            input ValidOneOfInput @oneOf {
+                field1: String
+                field2: Int
+            }
+            
+            type Query {
+                test(input: ValidOneOfInput): String
+            }
+        ");
+
+        // When
+        var schema = await builder.Build(new SchemaBuildOptions());
+
+        // Then
+        Assert.NotNull(schema);
+        var inputType = schema.GetNamedType("ValidOneOfInput");
+        Assert.NotNull(inputType);
+    }
+
+    [Fact]
+    public async Task Schema_validation_should_fail_for_oneOf_with_no_fields()
+    {
+        // Given
+        var builder = new SchemaBuilder();
+        builder.Add(@"
+            input EmptyOneOfInput @oneOf {
+            }
+            
+            type Query {
+                test(input: EmptyOneOfInput): String
+            }
+        ");
+
+        // When & Then
+        var exception = await Assert.ThrowsAsync<SchemaValidationException>(async () =>
+        {
+            await builder.Build(new SchemaBuildOptions());
+        });
+
+        Assert.Contains("must have at least one field", exception.Message);
+        Assert.Single(exception.Errors);
+    }
+}


### PR DESCRIPTION
## Summary

This PR implements a comprehensive schema validation infrastructure from the ground up, with full @oneOf directive RFC Stage 3 compliance. The new system validates GraphQL schemas at build time, providing early detection of schema issues and ensuring RFC compliance.

## Key Features

### 🏗️ Schema Validation Infrastructure
- **Complete validation framework** with `ISchemaValidator`, `SchemaValidator`, and `SchemaWalker`
- **Extensible rule system** via `SchemaValidationRule` base class
- **Rich error reporting** with `SchemaValidationError` and detailed context
- **Seamless integration** into existing `SchemaBuilder.Build()` workflow

### 📋 @oneOf RFC Stage 3 Compliance
- ✅ **Schema-time validation** preventing @oneOf input fields from having default values
- ✅ **Schema-time validation** ensuring @oneOf input objects have at least one field
- ✅ **Introspection support** with new `__Type.isOneOf` field 
- ✅ **Runtime validation** (existing functionality preserved)

### ⚡ Architecture Highlights
- **Validates after directive visitors** - Ensures validation of final transformed schema
- **Built-in rules enabled by default** - Zero configuration required
- **Clean separation from execution validation** - Different concerns, different systems
- **Performance optimized** - Validates once at schema build time, not per query

## Files Changed

### Core Infrastructure
- `src/GraphQL/TypeSystem/SchemaValidation/` - New validation framework (9 files)
- `src/GraphQL/TypeSystem/SchemaBuilder.cs` - Integration point for validation
- `src/GraphQL/TypeSystem/SchemaBuildOptions.cs` - Configuration support

### Introspection Enhancement  
- `src/GraphQL/Introspection/IntrospectionSchema.cs` - Added `isOneOf` field
- `src/GraphQL/Introspection/IntrospectionResolvers.cs` - Resolver for `isOneOf`

### Testing
- `tests/GraphQL.Tests/SchemaValidation/` - Comprehensive test coverage

## Testing

All tests pass including new schema validation tests:

```bash
dotnet test tests/GraphQL.Tests/ --filter "SchemaValidation"
# ✅ Schema_validation_should_fail_for_oneOf_with_default_value
# ✅ Schema_validation_should_pass_for_valid_oneOf  
# ✅ Schema_validation_should_fail_for_oneOf_with_no_fields
```

## Breaking Changes

**None** - This is a purely additive change:
- Existing schemas continue to work unchanged
- New validation runs automatically but only affects invalid schemas
- All existing APIs remain compatible

## Usage Examples

### Automatic Validation (Default)
```csharp
var builder = new SchemaBuilder();
builder.Add(@"
    input UserInput @oneOf {
        id: ID
        email: String
        # No default values allowed - will be caught at build time
    }
");

var schema = await builder.Build(new SchemaBuildOptions());
// ✅ Builds successfully - valid @oneOf schema
```

### Custom Validation Rules
```csharp
var options = new SchemaBuildOptions
{
    SchemaValidationRules = BuiltInSchemaValidationRules.All
        .Concat([new MyCustomValidationRule()])
};
```

### Introspection Query
```graphql
{
  __type(name: "UserInput") {
    isOneOf  # Returns true for @oneOf input objects
  }
}
```

## Implementation Details

- **Validation timing**: After directive visitors transform the schema
- **Error handling**: Collects all validation errors, throws comprehensive exception
- **Rule registration**: Built-in rules automatically included, fully customizable
- **Performance**: O(n) complexity where n = number of type definitions

## Future Enhancements

This infrastructure enables future schema validation rules for:
- Custom naming conventions
- Field relationship constraints  
- Federation-specific validations
- Performance optimization rules

🤖 Generated with [Claude Code](https://claude.ai/code)