### PR TITLE
fix: Prevent information disclosure in error responses

### DIFF
--- a/src/GraphQL.Server/GraphQLHttpTransportMiddleware.cs
+++ b/src/GraphQL.Server/GraphQLHttpTransportMiddleware.cs
@@ -42,7 +42,7 @@ public partial class GraphQLHttpTransportMiddleware(ILogger<GraphQLHttpTransport
             await httpContext.Response.WriteAsJsonAsync(new ProblemDetails
             {
                 Title = "Could not parse GraphQL request from body of the request",
-                Detail = x.Message // could this leak?
+                Detail = "Invalid request format or content"
             });
 
             Log.RequestParseError(logger, x);
@@ -215,7 +215,7 @@ public partial class GraphQLHttpTransportMiddleware(ILogger<GraphQLHttpTransport
 
         httpResponse.Body = originalBody;
         memoryStream.Position = 0;
-        
+
         using var reader = new StreamReader(memoryStream);
         var json = await reader.ReadToEndAsync();
         await writer.WriteAsync(json);

--- a/tests/GraphQL.Server.Tests/GraphQLHttpTransportSecurityTests.cs
+++ b/tests/GraphQL.Server.Tests/GraphQLHttpTransportSecurityTests.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+using Xunit;
+
+namespace Tanka.GraphQL.Server.Tests;
+
+public class GraphQLHttpTransportSecurityTests : IClassFixture<TankaGraphQLServerFactory>
+{
+    private readonly TankaGraphQLServerFactory _factory;
+
+    public GraphQLHttpTransportSecurityTests(TankaGraphQLServerFactory factory)
+    {
+        _factory = factory;
+    }
+
+    [Fact]
+    public async Task Should_Not_Leak_Exception_Details_In_Error_Response()
+    {
+        // Arrange
+        var client = _factory.CreateClient();
+
+        // Create malformed JSON that will trigger a parsing exception
+        var malformedJson = "{ invalid json that will cause detailed parsing error }";
+        var content = new StringContent(malformedJson, Encoding.UTF8, "application/json");
+
+        // Act
+        var response = await client.PostAsync("/graphql", content);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+
+        var responseContent = await response.Content.ReadAsStringAsync();
+        var problemDetails = JsonSerializer.Deserialize<ProblemDetails>(responseContent, new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true
+        });
+
+        // Verify that the response contains only generic error message
+        Assert.NotNull(problemDetails);
+        Assert.Equal("Could not parse GraphQL request from body of the request", problemDetails.Title);
+        Assert.Equal("Invalid request format or content", problemDetails.Detail);
+
+        // Verify that sensitive implementation details are NOT leaked
+        // Should not contain detailed JSON parsing error messages
+        Assert.DoesNotContain("LineNumber", responseContent);
+        Assert.DoesNotContain("BytePositionInLine", responseContent);
+        Assert.DoesNotContain("JsonException", responseContent);
+        Assert.DoesNotContain("JsonReaderException", responseContent);
+        Assert.DoesNotContain("Exception", responseContent, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("Stack", responseContent, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("System.", responseContent);
+        Assert.DoesNotContain("file://", responseContent, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("at System", responseContent);
+        Assert.DoesNotContain("ThrowHelper", responseContent);
+    }
+
+    [Fact]
+    public async Task Should_Handle_Valid_Request_Normally_After_Security_Fix()
+    {
+        // Arrange
+        var client = _factory.CreateClient();
+
+        // Create a valid GraphQL request
+        var validRequest = new
+        {
+            query = "{ __typename }"
+        };
+        var json = JsonSerializer.Serialize(validRequest);
+        var content = new StringContent(json, Encoding.UTF8, "application/json");
+
+        // Act
+        var response = await client.PostAsync("/graphql", content);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var responseContent = await response.Content.ReadAsStringAsync();
+        Assert.Contains("__typename", responseContent);
+    }
+}


### PR DESCRIPTION
## Summary
- Fix information disclosure vulnerability in GraphQLHttpTransportMiddleware
- Replace sensitive exception messages with generic error responses
- Add comprehensive security tests to verify the fix

## Security Issue
The middleware was previously exposing raw exception messages (`x.Message`) in error responses, which could potentially leak sensitive implementation details or system information to clients.

## Fix
- Replace `Detail = x.Message` with generic `Detail = "Invalid request format or content"`
- Add unit tests to verify no sensitive information is exposed in error responses
- Ensure all error scenarios return safe, generic error messages

## Test plan
- [x] All existing tests pass
- [x] New security tests verify generic error messages
- [x] Manual testing confirms no implementation details are leaked
- [x] Error handling remains functional for debugging purposes (server-side logging unchanged)

🤖 Generated with [Claude Code](https://claude.ai/code)