### PR TITLE
fix: Fix Apollo Federation documentation with proper code examples

### DIFF
--- a/docs/10-extensions/apollo-federation.md
+++ b/docs/10-extensions/apollo-federation.md
@@ -35,7 +35,7 @@ Creating a federated subgraph involves three main steps:
 
 #### Basic Example
 
-#include::xref://tests:GraphQL.Extensions.ApolloFederation.Tests/FederationDocumentationExamples.cs?s=Tanka.GraphQL.Extensions.ApolloFederation.Tests.FederationDocumentationExamples.BasicFederationExample
+#include::xref://tests:GraphQL.Extensions.ApolloFederation.Tests/FederationDocumentationCodeExamples.cs?s=Tanka.GraphQL.Extensions.ApolloFederation.Tests.FederationDocumentationCodeExamples.BasicFederationExample
 
 ### Advanced Features
 
@@ -56,19 +56,19 @@ extend schema @link(url: "https://specs.apollo.dev/federation/v2.3",
 
 Federation support is seamlessly integrated into the schema builder's middleware pipeline:
 
-#include::xref://tests:GraphQL.Extensions.ApolloFederation.Tests/FederationDocumentationExamples.cs?s=Tanka.GraphQL.Extensions.ApolloFederation.Tests.FederationDocumentationExamples.MiddlewarePipelineIntegration
+#include::xref://tests:GraphQL.Extensions.ApolloFederation.Tests/FederationDocumentationCodeExamples.cs?s=Tanka.GraphQL.Extensions.ApolloFederation.Tests.FederationDocumentationCodeExamples.MiddlewarePipelineIntegration
 
 ### Reference Resolvers
 
 Reference resolvers handle entity resolution when the gateway requests entities by their key fields:
 
-#include::xref://tests:GraphQL.Extensions.ApolloFederation.Tests/FederationDocumentationExamples.cs?s=Tanka.GraphQL.Extensions.ApolloFederation.Tests.FederationDocumentationExamples.ReferenceResolverExample
+#include::xref://tests:GraphQL.Extensions.ApolloFederation.Tests/FederationDocumentationCodeExamples.cs?s=Tanka.GraphQL.Extensions.ApolloFederation.Tests.FederationDocumentationCodeExamples.ReferenceResolverExample
 
 ### Federation Directives
 
 Tanka GraphQL supports all Apollo Federation v2.3 directives:
 
-#include::xref://tests:GraphQL.Extensions.ApolloFederation.Tests/FederationDocumentationExamples.cs?s=Tanka.GraphQL.Extensions.ApolloFederation.Tests.FederationDocumentationExamples.FederationDirectivesExample
+#include::xref://tests:GraphQL.Extensions.ApolloFederation.Tests/FederationDocumentationCodeExamples.cs?s=Tanka.GraphQL.Extensions.ApolloFederation.Tests.FederationDocumentationCodeExamples.FederationDirectivesExample
 
 The supported directives include:
 - `@key` - Define entity key fields
@@ -97,17 +97,17 @@ dotnet run
 
 If you're migrating from Apollo Federation v1, update your schema to use the `@link` directive:
 
-#include::xref://tests:GraphQL.Extensions.ApolloFederation.Tests/FederationDocumentationExamples.cs?s=Tanka.GraphQL.Extensions.ApolloFederation.Tests.FederationDocumentationExamples.MigrationFromV1Example
+#include::xref://tests:GraphQL.Extensions.ApolloFederation.Tests/FederationDocumentationCodeExamples.cs?s=Tanka.GraphQL.Extensions.ApolloFederation.Tests.FederationDocumentationCodeExamples.MigrationFromV1Example
 
 ### Best Practices
 
 1. **Use specific imports** - Only import the federation directives you actually use:
 
-#include::xref://tests:GraphQL.Extensions.ApolloFederation.Tests/FederationDocumentationExamples.cs?s=Tanka.GraphQL.Extensions.ApolloFederation.Tests.FederationDocumentationExamples.SpecificImportsExample
+#include::xref://tests:GraphQL.Extensions.ApolloFederation.Tests/FederationDocumentationCodeExamples.cs?s=Tanka.GraphQL.Extensions.ApolloFederation.Tests.FederationDocumentationCodeExamples.SpecificImportsExample
 
 2. **Handle null entities** - Reference resolvers should handle cases where entities don't exist:
 
-#include::xref://tests:GraphQL.Extensions.ApolloFederation.Tests/FederationDocumentationExamples.cs?s=Tanka.GraphQL.Extensions.ApolloFederation.Tests.FederationDocumentationExamples.ErrorHandlingExample
+#include::xref://tests:GraphQL.Extensions.ApolloFederation.Tests/FederationDocumentationCodeExamples.cs?s=Tanka.GraphQL.Extensions.ApolloFederation.Tests.FederationDocumentationCodeExamples.ErrorHandlingExample
 
 3. **Optimize key selection** - Choose efficient key fields for entity resolution
 4. **Test compatibility** - Use the Apollo Federation compatibility suite to validate your subgraph

--- a/docs/10-extensions/apollo-federation.md
+++ b/docs/10-extensions/apollo-federation.md
@@ -35,117 +35,42 @@ Creating a federated subgraph involves three main steps:
 
 #### Basic Example
 
-```csharp
-// 1. Define schema with @link directive for Federation v2.3
-var schema = @"
-extend schema @link(url: ""https://specs.apollo.dev/federation/v2.3"", 
-                   import: [""@key"", ""@external"", ""@requires"", ""@provides""])
-
-type Product @key(fields: ""id"") {
-    id: ID!
-    name: String
-    price: Float
-}
-
-type Query {
-    product(id: ID!): Product
-}";
-
-// 2. Configure reference resolvers for entity resolution
-var referenceResolvers = new DictionaryReferenceResolversMap
-{
-    [""Product""] = (context, type, representation) =>
-    {
-        var id = representation.GetValueOrDefault(""id"")?.ToString();
-        var product = GetProductById(id); // Your data access logic
-        return ValueTask.FromResult(new ResolveReferenceResult(type, product));
-    }
-};
-
-// 3. Build executable schema with federation support
-var executableSchema = new ExecutableSchemaBuilder()
-    .Add(schema)
-    .AddApolloFederation(new SubgraphOptions(referenceResolvers))
-    .Build();
-```
+#include::xref://tests:GraphQL.Extensions.ApolloFederation.Tests/FederationDocumentationExamples.cs?s=Tanka.GraphQL.Extensions.ApolloFederation.Tests.FederationDocumentationExamples.BasicFederationExample
 
 ### Advanced Features
 
 #### Schema Composition with @link
 
-Apollo Federation v2.3 uses the `@link` directive for schema composition. Tanka GraphQL automatically processes these directives and imports the required types and directives:
+Apollo Federation v2.3 uses the `@link` directive for schema composition. Tanka GraphQL automatically processes these directives and imports the required types and directives.
+
+#### Type Aliasing (Planned Feature)
+
+Note: Type aliasing with the `as` keyword is planned for a future release. Currently, you should import directives using their standard names:
 
 ```graphql
 extend schema @link(url: "https://specs.apollo.dev/federation/v2.3", 
-                   import: ["@key", "@external", "@requires", "@provides"])
-```
-
-#### Type Aliasing
-
-You can use aliases to avoid naming conflicts when importing federation types:
-
-```graphql
-extend schema @link(url: "https://specs.apollo.dev/federation/v2.3", 
-                   import: [{name: "@key", as: "@primaryKey"}, "@external"])
-
-type Product @primaryKey(fields: "id") {
-    id: ID!
-}
+                   import: ["@key", "@external"])
 ```
 
 #### Middleware Pipeline Integration
 
 Federation support is seamlessly integrated into the schema builder's middleware pipeline:
 
-```csharp
-var schema = new SchemaBuilder()
-    .Add(schemaSDL)
-    .Build(options =>
-    {
-        options.Resolvers = resolvers;
-        options.AddApolloFederation(subgraphOptions);
-    });
-```
-
-The federation middleware automatically:
-- Processes `@link` directives and imports required types
-- Adds `_service` and `_entities` fields to the Query type
-- Configures entity resolution based on your reference resolvers
-- Generates proper subgraph SDL for federation
+#include::xref://tests:GraphQL.Extensions.ApolloFederation.Tests/FederationDocumentationExamples.cs?s=Tanka.GraphQL.Extensions.ApolloFederation.Tests.FederationDocumentationExamples.MiddlewarePipelineIntegration
 
 ### Reference Resolvers
 
 Reference resolvers handle entity resolution when the gateway requests entities by their key fields:
 
-```csharp
-var referenceResolvers = new DictionaryReferenceResolversMap
-{
-    ["Product"] = async (context, type, representation) =>
-    {
-        // Extract key fields from representation
-        var id = representation.GetValueOrDefault("id")?.ToString();
-        var sku = representation.GetValueOrDefault("sku")?.ToString();
-        
-        // Resolve entity based on key fields
-        Product? product = null;
-        if (id != null)
-        {
-            product = await productService.GetByIdAsync(id);
-        }
-        else if (sku != null)
-        {
-            product = await productService.GetBySkuAsync(sku);
-        }
-        
-        return new ResolveReferenceResult(type, product);
-    }
-};
-```
+#include::xref://tests:GraphQL.Extensions.ApolloFederation.Tests/FederationDocumentationExamples.cs?s=Tanka.GraphQL.Extensions.ApolloFederation.Tests.FederationDocumentationExamples.ReferenceResolverExample
 
 ### Federation Directives
 
 Tanka GraphQL supports all Apollo Federation v2.3 directives:
 
+#include::xref://tests:GraphQL.Extensions.ApolloFederation.Tests/FederationDocumentationExamples.cs?s=Tanka.GraphQL.Extensions.ApolloFederation.Tests.FederationDocumentationExamples.FederationDirectivesExample
+
+The supported directives include:
 - `@key` - Define entity key fields
 - `@external` - Mark fields as owned by other subgraphs  
 - `@requires` - Specify required fields for computed fields
@@ -172,24 +97,18 @@ dotnet run
 
 If you're migrating from Apollo Federation v1, update your schema to use the `@link` directive:
 
-```diff
-- # Federation v1 (deprecated)
-- extend type Query {
--   _entities(representations: [_Any!]!): [_Entity]!
--   _service: _Service!
-- }
-
-+ # Federation v2.3
-+ extend schema @link(url: "https://specs.apollo.dev/federation/v2.3", 
-+                    import: ["@key", "@external"])
-```
-
-The middleware will automatically handle the migration and add the required fields.
+#include::xref://tests:GraphQL.Extensions.ApolloFederation.Tests/FederationDocumentationExamples.cs?s=Tanka.GraphQL.Extensions.ApolloFederation.Tests.FederationDocumentationExamples.MigrationFromV1Example
 
 ### Best Practices
 
-1. **Use specific imports** - Only import the federation directives you actually use
-2. **Handle null entities** - Reference resolvers should handle cases where entities don't exist
+1. **Use specific imports** - Only import the federation directives you actually use:
+
+#include::xref://tests:GraphQL.Extensions.ApolloFederation.Tests/FederationDocumentationExamples.cs?s=Tanka.GraphQL.Extensions.ApolloFederation.Tests.FederationDocumentationExamples.SpecificImportsExample
+
+2. **Handle null entities** - Reference resolvers should handle cases where entities don't exist:
+
+#include::xref://tests:GraphQL.Extensions.ApolloFederation.Tests/FederationDocumentationExamples.cs?s=Tanka.GraphQL.Extensions.ApolloFederation.Tests.FederationDocumentationExamples.ErrorHandlingExample
+
 3. **Optimize key selection** - Choose efficient key fields for entity resolution
 4. **Test compatibility** - Use the Apollo Federation compatibility suite to validate your subgraph
 5. **Monitor performance** - Entity resolution can impact query performance in large federations
@@ -203,14 +122,37 @@ The middleware will automatically handle the migration and add the required fiel
 - **Type conflicts**: Use aliasing in @link imports to resolve naming conflicts
 - **Schema validation errors**: Verify that all imported directives are properly used in your schema
 
-#### Debug Mode
+#### Federation Schema Loader
 
-Enable detailed logging to troubleshoot federation issues:
+Tanka GraphQL includes a `FederationSchemaLoader` that automatically loads Federation v2.3 types when processing `@link` directives pointing to Apollo Federation specifications. This loader is automatically configured when you use `UseFederation()`.
+
+### API Reference
+
+#### SubgraphOptions
+
+Configure your subgraph with reference resolvers:
 
 ```csharp
-builder.Services.AddLogging(logging =>
+var options = new SubgraphOptions(referenceResolvers)
 {
-    logging.AddConsole();
-    logging.SetMinimumLevel(LogLevel.Debug);
-});
+    // Optionally specify a different Federation version
+    FederationSpecUrl = "https://specs.apollo.dev/federation/v2.3",
+    
+    // Optionally specify which types to import (null imports all)
+    ImportList = new[] { "@key", "@external", "@requires" }
+};
 ```
+
+#### UseFederation Extension
+
+Add Federation support to your schema builder:
+
+```csharp
+options.UseFederation(subgraphOptions);
+```
+
+This extension method:
+- Adds Federation value converters for `_Any` and `FieldSet` scalars
+- Configures the Federation schema loader
+- Adds initialization middleware to process `@link` directives
+- Adds configuration middleware to set up entity resolution

--- a/tests/GraphQL.Extensions.ApolloFederation.Tests/FederationDocumentationCodeExamples.cs
+++ b/tests/GraphQL.Extensions.ApolloFederation.Tests/FederationDocumentationCodeExamples.cs
@@ -1,0 +1,319 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+using Tanka.GraphQL.Executable;
+using Tanka.GraphQL.Fields;
+using Tanka.GraphQL.Language.Nodes.TypeSystem;
+using Tanka.GraphQL.Request;
+using Tanka.GraphQL.TypeSystem;
+using Tanka.GraphQL.ValueResolution;
+
+namespace Tanka.GraphQL.Extensions.ApolloFederation.Tests;
+
+/// <summary>
+/// Clean code examples for Apollo Federation documentation
+/// These contain only the relevant code without test attributes
+/// </summary>
+public class FederationDocumentationCodeExamples
+{
+    public static async Task BasicFederationExample()
+    {
+        // 1. Define schema with @link directive for Federation v2.3
+        var schema = """
+            extend schema @link(url: "https://specs.apollo.dev/federation/v2.3", 
+                               import: ["@key", "@external", "@requires", "@provides"])
+
+            type Product @key(fields: "id") {
+                id: ID!
+                name: String
+                price: Float
+            }
+
+            type Query {
+                product(id: ID!): Product
+            }
+            """;
+
+        // 2. Configure reference resolvers for entity resolution
+        var referenceResolvers = new DictionaryReferenceResolversMap
+        {
+            ["Product"] = (context, type, representation) =>
+            {
+                var id = representation.GetValueOrDefault("id")?.ToString();
+                var product = GetProductById(id); // Your data access logic
+                return ValueTask.FromResult(new ResolveReferenceResult(type, product));
+            }
+        };
+
+        // 3. Build executable schema with federation support
+        var executableSchema = await new ExecutableSchemaBuilder()
+            .Add(schema)
+            .Add("Query", new FieldsWithResolvers
+            {
+                ["product(id: ID!): Product"] = b => b.Run(context =>
+                {
+                    var id = context.GetArgument<string>("id");
+                    context.ResolvedValue = GetProductById(id);
+                    return ValueTask.CompletedTask;
+                })
+            })
+            .Build(options =>
+            {
+                options.UseFederation(new SubgraphOptions(referenceResolvers));
+            });
+    }
+
+    public static async Task MiddlewarePipelineIntegration()
+    {
+        var schemaSDL = """
+            extend schema @link(url: "https://specs.apollo.dev/federation/v2.3", 
+                               import: ["@key", "@external"])
+
+            type Product @key(fields: "id") {
+                id: ID!
+                name: String
+            }
+
+            type Query {
+                product(id: ID!): Product
+            }
+            """;
+
+        var resolversBuilder = new ResolversBuilder();
+        resolversBuilder.Resolver("Query", "product").Run(context =>
+        {
+            context.ResolvedValue = new { id = "1", name = "Test Product" };
+            return ValueTask.CompletedTask;
+        });
+
+        var subgraphOptions = new SubgraphOptions(new DictionaryReferenceResolversMap());
+
+        var schema = await new SchemaBuilder()
+            .Add(schemaSDL)
+            .Build(options =>
+            {
+                options.Resolvers = resolversBuilder.BuildResolvers();
+                options.UseFederation(subgraphOptions);
+            });
+
+        // The federation middleware automatically:
+        // - Processes @link directives and imports required types
+        // - Adds _service and _entities fields to the Query type
+        // - Configures entity resolution based on your reference resolvers
+        // - Generates proper subgraph SDL for federation
+    }
+
+    public static async Task ReferenceResolverExample()
+    {
+        var schema = """
+            extend schema @link(url: "https://specs.apollo.dev/federation/v2.3", 
+                               import: ["@key"])
+
+            type Product @key(fields: "id") @key(fields: "sku") {
+                id: ID!
+                sku: String!
+                name: String
+            }
+
+            type Query {
+                product(id: ID!): Product
+            }
+            """;
+
+        // Reference resolvers handle entity resolution when the gateway requests entities by their key fields
+        var referenceResolvers = new DictionaryReferenceResolversMap
+        {
+            ["Product"] = async (context, type, representation) =>
+            {
+                // Extract key fields from representation
+                var id = representation.GetValueOrDefault("id")?.ToString();
+                var sku = representation.GetValueOrDefault("sku")?.ToString();
+
+                // Resolve entity based on key fields
+                Product? product = null;
+                if (id != null)
+                {
+                    product = await GetProductByIdAsync(id);
+                }
+                else if (sku != null)
+                {
+                    product = await GetProductBySkuAsync(sku);
+                }
+
+                return new ResolveReferenceResult(type, product);
+            }
+        };
+
+        var executableSchema = await new ExecutableSchemaBuilder()
+            .Add(schema)
+            .Build(options =>
+            {
+                options.UseFederation(new SubgraphOptions(referenceResolvers));
+            });
+    }
+
+    public static async Task FederationDirectivesExample()
+    {
+        // Tanka GraphQL supports all Apollo Federation v2.3 directives
+        var schema = """
+            extend schema @link(url: "https://specs.apollo.dev/federation/v2.3", 
+                               import: ["@key", "@external", "@requires", "@provides", 
+                                       "@shareable", "@inaccessible", "@override", 
+                                       "@tag", "@extends", "@composeDirective", "@interfaceObject"])
+
+            type Product @key(fields: "id") @shareable {
+                id: ID!
+                name: String @inaccessible
+                price: Float @tag(name: "public")
+                weight: Float @external
+                shippingCost: Float @requires(fields: "weight")
+            }
+
+            type Review @key(fields: "id") {
+                id: ID!
+                product: Product @provides(fields: "name")
+                rating: Int
+            }
+
+            type Query {
+                product(id: ID!): Product
+            }
+            """;
+
+        var executableSchema = await new ExecutableSchemaBuilder()
+            .Add(schema)
+            .Build(options =>
+            {
+                options.UseFederation(new SubgraphOptions(new DictionaryReferenceResolversMap()));
+            });
+    }
+
+    public static async Task MigrationFromV1Example()
+    {
+        // Federation v2.3 - Use @link directive instead of manually defining federation types
+        var schemaV2 = """
+            extend schema @link(url: "https://specs.apollo.dev/federation/v2.3", 
+                                import: ["@key", "@external"])
+
+            type Product @key(fields: "id") {
+                id: ID!
+                name: String
+            }
+
+            type Query {
+                product(id: ID!): Product
+            }
+            """;
+
+        var executableSchema = await new ExecutableSchemaBuilder()
+            .Add(schemaV2)
+            .Build(options =>
+            {
+                options.UseFederation(new SubgraphOptions(new DictionaryReferenceResolversMap()));
+            });
+
+        // The middleware automatically handles the migration and adds the required fields
+    }
+
+    public static async Task SpecificImportsExample()
+    {
+        // Best practice: Only import the federation directives you actually use
+        var schema = """
+            extend schema @link(url: "https://specs.apollo.dev/federation/v2.3", 
+                               import: ["@key", "@shareable"])
+
+            type Product @key(fields: "id") @shareable {
+                id: ID!
+                name: String
+            }
+
+            type Query {
+                product(id: ID!): Product
+            }
+            """;
+
+        var executableSchema = await new ExecutableSchemaBuilder()
+            .Add(schema)
+            .Build(options =>
+            {
+                options.UseFederation(new SubgraphOptions(new DictionaryReferenceResolversMap()));
+            });
+    }
+
+    public static async Task ErrorHandlingExample()
+    {
+        var schema = """
+            extend schema @link(url: "https://specs.apollo.dev/federation/v2.3", 
+                               import: ["@key"])
+
+            type Product @key(fields: "id") {
+                id: ID!
+                name: String
+            }
+
+            type Query {
+                product(id: ID!): Product
+            }
+            """;
+
+        // Handle null entities - Reference resolvers should handle cases where entities don't exist
+        var referenceResolvers = new DictionaryReferenceResolversMap
+        {
+            ["Product"] = (context, type, representation) =>
+            {
+                var id = representation.GetValueOrDefault("id")?.ToString();
+
+                // Handle missing entities gracefully
+                if (string.IsNullOrEmpty(id))
+                {
+                    return ValueTask.FromResult(new ResolveReferenceResult(type, null));
+                }
+
+                var product = GetProductById(id);
+                if (product == null)
+                {
+                    // Return null for non-existent entities
+                    return ValueTask.FromResult(new ResolveReferenceResult(type, null));
+                }
+
+                return ValueTask.FromResult(new ResolveReferenceResult(type, product));
+            }
+        };
+
+        var executableSchema = await new ExecutableSchemaBuilder()
+            .Add(schema)
+            .Build(options =>
+            {
+                options.UseFederation(new SubgraphOptions(referenceResolvers));
+            });
+    }
+
+    // Helper methods for examples
+    private static Product? GetProductById(string? id)
+    {
+        if (id == "1")
+            return new Product { Id = "1", Name = "Test Product", Price = 99.99f };
+        return null;
+    }
+
+    private static Task<Product?> GetProductByIdAsync(string id)
+    {
+        return Task.FromResult(GetProductById(id));
+    }
+
+    private static Task<Product?> GetProductBySkuAsync(string sku)
+    {
+        if (sku == "SKU123")
+            return Task.FromResult<Product?>(new Product { Id = "1", Sku = "SKU123", Name = "Test Product" });
+        return Task.FromResult<Product?>(null);
+    }
+
+    private class Product
+    {
+        public string Id { get; set; } = "";
+        public string? Sku { get; set; }
+        public string Name { get; set; } = "";
+        public float Price { get; set; }
+    }
+}

--- a/tests/GraphQL.Extensions.ApolloFederation.Tests/FederationDocumentationExamples.cs
+++ b/tests/GraphQL.Extensions.ApolloFederation.Tests/FederationDocumentationExamples.cs
@@ -1,0 +1,399 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+using Tanka.GraphQL.Executable;
+using Tanka.GraphQL.Fields;
+using Tanka.GraphQL.Language.Nodes.TypeSystem;
+using Tanka.GraphQL.Request;
+using Tanka.GraphQL.TypeSystem;
+using Tanka.GraphQL.ValueResolution;
+
+using Xunit;
+
+namespace Tanka.GraphQL.Extensions.ApolloFederation.Tests;
+
+/// <summary>
+/// Documentation examples for Apollo Federation
+/// These tests serve as the source for code samples in the documentation
+/// </summary>
+public class FederationDocumentationExamples
+{
+    [Fact]
+    public async Task BasicFederationExample()
+    {
+        // 1. Define schema with @link directive for Federation v2.3
+        var schema = @"
+extend schema @link(url: ""https://specs.apollo.dev/federation/v2.3"", 
+                   import: [""@key"", ""@external"", ""@requires"", ""@provides""])
+
+type Product @key(fields: ""id"") {
+    id: ID!
+    name: String
+    price: Float
+}
+
+type Query {
+    product(id: ID!): Product
+}";
+
+        // 2. Configure reference resolvers for entity resolution
+        var referenceResolvers = new DictionaryReferenceResolversMap
+        {
+            ["Product"] = (context, type, representation) =>
+            {
+                var id = representation.GetValueOrDefault("id")?.ToString();
+                var product = GetProductById(id); // Your data access logic
+                return ValueTask.FromResult(new ResolveReferenceResult(type, product));
+            }
+        };
+
+        // 3. Build executable schema with federation support
+        var executableSchema = await new ExecutableSchemaBuilder()
+            .Add(schema)
+            .Add("Query", new FieldsWithResolvers
+            {
+                ["product(id: ID!): Product"] = b => b.Run(context =>
+                {
+                    var id = context.GetArgument<string>("id");
+                    context.ResolvedValue = GetProductById(id);
+                    return ValueTask.CompletedTask;
+                })
+            })
+            .Build(options =>
+            {
+                options.UseFederation(new SubgraphOptions(referenceResolvers));
+            });
+
+        Assert.NotNull(executableSchema);
+        Assert.NotNull(executableSchema.GetNamedType("Product"));
+        Assert.NotNull(executableSchema.GetDirectiveType("key"));
+    }
+
+    [Fact(Skip = "Type aliasing with 'as' is not yet implemented")]
+    public async Task TypeAliasingExample()
+    {
+        // Note: Type aliasing support is planned for a future release
+        // Using aliases to avoid naming conflicts when importing federation types
+        var schema = @"
+extend schema @link(url: ""https://specs.apollo.dev/federation/v2.3"", 
+                   import: [{name: ""@key"", as: ""@primaryKey""}, ""@external""])
+
+type Product @primaryKey(fields: ""id"") {
+    id: ID!
+    name: String
+}
+
+type Query {
+    product(id: ID!): Product
+}";
+
+        var executableSchema = await new ExecutableSchemaBuilder()
+            .Add(schema)
+            .Build(options =>
+            {
+                options.UseFederation(new SubgraphOptions(new DictionaryReferenceResolversMap()));
+            });
+
+        Assert.NotNull(executableSchema);
+        // The @key directive is imported as @primaryKey
+        var primaryKeyDirective = executableSchema.GetDirectiveType("primaryKey");
+        Assert.NotNull(primaryKeyDirective);
+    }
+
+    [Fact]
+    public async Task MiddlewarePipelineIntegration()
+    {
+        var schemaSDL = @"
+extend schema @link(url: ""https://specs.apollo.dev/federation/v2.3"", 
+                   import: [""@key"", ""@external""])
+
+type Product @key(fields: ""id"") {
+    id: ID!
+    name: String
+}
+
+type Query {
+    product(id: ID!): Product
+}";
+
+        var resolversBuilder = new ResolversBuilder();
+        resolversBuilder.Resolver("Query", "product").Run(context =>
+        {
+            context.ResolvedValue = new { id = "1", name = "Test Product" };
+            return ValueTask.CompletedTask;
+        });
+
+        var subgraphOptions = new SubgraphOptions(new DictionaryReferenceResolversMap());
+
+        var schema = await new SchemaBuilder()
+            .Add(schemaSDL)
+            .Build(options =>
+            {
+                options.Resolvers = resolversBuilder.BuildResolvers();
+                options.UseFederation(subgraphOptions);
+            });
+
+        // The federation middleware automatically:
+        // - Processes @link directives and imports required types
+        // - Adds _service and _entities fields to the Query type
+        // - Configures entity resolution based on your reference resolvers
+        // - Generates proper subgraph SDL for federation
+
+        Assert.NotNull(schema);
+        var queryType = schema.GetNamedType("Query") as ObjectDefinition;
+        Assert.NotNull(queryType);
+
+        // Verify federation fields were added
+        var serviceField = queryType?.Fields.FirstOrDefault(f => f.Name == "_service");
+        var entitiesField = queryType?.Fields.FirstOrDefault(f => f.Name == "_entities");
+        Assert.NotNull(serviceField);
+        Assert.NotNull(entitiesField);
+    }
+
+    [Fact]
+    public async Task ReferenceResolverExample()
+    {
+        var schema = @"
+extend schema @link(url: ""https://specs.apollo.dev/federation/v2.3"", 
+                   import: [""@key""])
+
+type Product @key(fields: ""id"") @key(fields: ""sku"") {
+    id: ID!
+    sku: String!
+    name: String
+}
+
+type Query {
+    product(id: ID!): Product
+}";
+
+        // Reference resolvers handle entity resolution when the gateway requests entities by their key fields
+        var referenceResolvers = new DictionaryReferenceResolversMap
+        {
+            ["Product"] = async (context, type, representation) =>
+            {
+                // Extract key fields from representation
+                var id = representation.GetValueOrDefault("id")?.ToString();
+                var sku = representation.GetValueOrDefault("sku")?.ToString();
+
+                // Resolve entity based on key fields
+                Product? product = null;
+                if (id != null)
+                {
+                    product = await GetProductByIdAsync(id);
+                }
+                else if (sku != null)
+                {
+                    product = await GetProductBySkuAsync(sku);
+                }
+
+                return new ResolveReferenceResult(type, product);
+            }
+        };
+
+        var executableSchema = await new ExecutableSchemaBuilder()
+            .Add(schema)
+            .Build(options =>
+            {
+                options.UseFederation(new SubgraphOptions(referenceResolvers));
+            });
+
+        Assert.NotNull(executableSchema);
+    }
+
+    [Fact]
+    public async Task FederationDirectivesExample()
+    {
+        // Tanka GraphQL supports all Apollo Federation v2.3 directives
+        var schema = @"
+extend schema @link(url: ""https://specs.apollo.dev/federation/v2.3"", 
+                   import: [""@key"", ""@external"", ""@requires"", ""@provides"", 
+                           ""@shareable"", ""@inaccessible"", ""@override"", 
+                           ""@tag"", ""@extends"", ""@composeDirective"", ""@interfaceObject""])
+
+type Product @key(fields: ""id"") @shareable {
+    id: ID!
+    name: String @inaccessible
+    price: Float @tag(name: ""public"")
+    weight: Float @external
+    shippingCost: Float @requires(fields: ""weight"")
+}
+
+type Review @key(fields: ""id"") {
+    id: ID!
+    product: Product @provides(fields: ""name"")
+    rating: Int
+}
+
+type Query {
+    product(id: ID!): Product
+}";
+
+        var executableSchema = await new ExecutableSchemaBuilder()
+            .Add(schema)
+            .Build(options =>
+            {
+                options.UseFederation(new SubgraphOptions(new DictionaryReferenceResolversMap()));
+            });
+
+        Assert.NotNull(executableSchema);
+
+        // Verify all directives are available
+        Assert.NotNull(executableSchema.GetDirectiveType("key"));
+        Assert.NotNull(executableSchema.GetDirectiveType("external"));
+        Assert.NotNull(executableSchema.GetDirectiveType("requires"));
+        Assert.NotNull(executableSchema.GetDirectiveType("provides"));
+        Assert.NotNull(executableSchema.GetDirectiveType("shareable"));
+        Assert.NotNull(executableSchema.GetDirectiveType("inaccessible"));
+        Assert.NotNull(executableSchema.GetDirectiveType("override"));
+        Assert.NotNull(executableSchema.GetDirectiveType("tag"));
+        Assert.NotNull(executableSchema.GetDirectiveType("extends"));
+        Assert.NotNull(executableSchema.GetDirectiveType("composeDirective"));
+        Assert.NotNull(executableSchema.GetDirectiveType("interfaceObject"));
+    }
+
+    [Fact]
+    public async Task MigrationFromV1Example()
+    {
+        // Federation v2.3 - Use @link directive instead of manually defining federation types
+        var schemaV2 = @"
+extend schema @link(url: ""https://specs.apollo.dev/federation/v2.3"", 
+                    import: [""@key"", ""@external""])
+
+type Product @key(fields: ""id"") {
+    id: ID!
+    name: String
+}
+
+type Query {
+    product(id: ID!): Product
+}";
+
+        var executableSchema = await new ExecutableSchemaBuilder()
+            .Add(schemaV2)
+            .Build(options =>
+            {
+                options.UseFederation(new SubgraphOptions(new DictionaryReferenceResolversMap()));
+            });
+
+        // The middleware automatically handles the migration and adds the required fields
+        Assert.NotNull(executableSchema);
+
+        var queryType = executableSchema.GetNamedType("Query") as ObjectDefinition;
+        Assert.NotNull(queryType);
+
+        // Federation fields are automatically added
+        var serviceField = queryType?.Fields.FirstOrDefault(f => f.Name == "_service");
+        var entitiesField = queryType?.Fields.FirstOrDefault(f => f.Name == "_entities");
+        Assert.NotNull(serviceField);
+        Assert.NotNull(entitiesField);
+    }
+
+    [Fact]
+    public async Task SpecificImportsExample()
+    {
+        // Best practice: Only import the federation directives you actually use
+        var schema = @"
+extend schema @link(url: ""https://specs.apollo.dev/federation/v2.3"", 
+                   import: [""@key"", ""@shareable""])
+
+type Product @key(fields: ""id"") @shareable {
+    id: ID!
+    name: String
+}
+
+type Query {
+    product(id: ID!): Product
+}";
+
+        var executableSchema = await new ExecutableSchemaBuilder()
+            .Add(schema)
+            .Build(options =>
+            {
+                options.UseFederation(new SubgraphOptions(new DictionaryReferenceResolversMap()));
+            });
+
+        Assert.NotNull(executableSchema);
+        Assert.NotNull(executableSchema.GetDirectiveType("key"));
+        Assert.NotNull(executableSchema.GetDirectiveType("shareable"));
+    }
+
+    [Fact]
+    public async Task ErrorHandlingExample()
+    {
+        var schema = @"
+extend schema @link(url: ""https://specs.apollo.dev/federation/v2.3"", 
+                   import: [""@key""])
+
+type Product @key(fields: ""id"") {
+    id: ID!
+    name: String
+}
+
+type Query {
+    product(id: ID!): Product
+}";
+
+        // Handle null entities - Reference resolvers should handle cases where entities don't exist
+        var referenceResolvers = new DictionaryReferenceResolversMap
+        {
+            ["Product"] = (context, type, representation) =>
+            {
+                var id = representation.GetValueOrDefault("id")?.ToString();
+
+                // Handle missing entities gracefully
+                if (string.IsNullOrEmpty(id))
+                {
+                    return ValueTask.FromResult(new ResolveReferenceResult(type, null));
+                }
+
+                var product = GetProductById(id);
+                if (product == null)
+                {
+                    // Return null for non-existent entities
+                    return ValueTask.FromResult(new ResolveReferenceResult(type, null));
+                }
+
+                return ValueTask.FromResult(new ResolveReferenceResult(type, product));
+            }
+        };
+
+        var executableSchema = await new ExecutableSchemaBuilder()
+            .Add(schema)
+            .Build(options =>
+            {
+                options.UseFederation(new SubgraphOptions(referenceResolvers));
+            });
+
+        Assert.NotNull(executableSchema);
+    }
+
+    // Helper methods for examples
+    private static Product? GetProductById(string? id)
+    {
+        if (id == "1")
+            return new Product { Id = "1", Name = "Test Product", Price = 99.99f };
+        return null;
+    }
+
+    private static Task<Product?> GetProductByIdAsync(string id)
+    {
+        return Task.FromResult(GetProductById(id));
+    }
+
+    private static Task<Product?> GetProductBySkuAsync(string sku)
+    {
+        if (sku == "SKU123")
+            return Task.FromResult<Product?>(new Product { Id = "1", Sku = "SKU123", Name = "Test Product" });
+        return Task.FromResult<Product?>(null);
+    }
+
+    private class Product
+    {
+        public string Id { get; set; } = "";
+        public string? Sku { get; set; }
+        public string Name { get; set; } = "";
+        public float Price { get; set; }
+    }
+}


### PR DESCRIPTION
## Summary
This PR fixes several issues with the Apollo Federation documentation, ensuring all code examples are accurate, properly formatted, and backed by working unit tests.

## Issues Fixed
- **Incorrect API calls**: Documentation showed `AddApolloFederation` instead of the correct `UseFederation`
- **Broken formatting**: Code examples were split between HTML tags causing poor rendering
- **Test scaffolding in docs**: `[Fact]` attributes and test methods appeared in documentation
- **Unimplemented features**: Documentation showed type aliasing that isn't yet supported

## Changes Made
### Documentation Improvements
- ✅ Created comprehensive unit tests for all documentation examples (7 passing, 1 skipped for future feature)
- ✅ Fixed all API references to use `UseFederation(new SubgraphOptions(...))`
- ✅ Created clean code examples using raw string literals for proper formatting
- ✅ Updated all `#include::xref://` references to point to clean example code
- ✅ Noted that type aliasing with `as` is planned for future release
- ✅ Removed debug sections from documentation

### New Test Files
- `FederationDocumentationExamples.cs` - Unit tests validating all documentation examples
- `FederationDocumentationCodeExamples.cs` - Clean code examples for documentation inclusion

## Test Results
All documentation examples now:
- Compile successfully
- Pass their unit tests
- Use the correct API
- Render properly as formatted code blocks
- Build successfully with `dotnet tanka-docs build`

## Breaking Changes
None - this is a documentation-only fix.

🤖 Generated with [Claude Code](https://claude.ai/code)