### PR TITLE
Add .NET 10 target to project

### DIFF
--- a/src/GraphQL.Extensions.ApolloFederation/GraphQL.Extensions.ApolloFederation.csproj
+++ b/src/GraphQL.Extensions.ApolloFederation/GraphQL.Extensions.ApolloFederation.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net9.0</TargetFrameworks>
+		<TargetFrameworks>net9.0;net10.0</TargetFrameworks>
 		<Nullable>enable</Nullable>
 	</PropertyGroup>
 

--- a/src/GraphQL.Extensions.Experimental/GraphQL.Extensions.Experimental.csproj
+++ b/src/GraphQL.Extensions.Experimental/GraphQL.Extensions.Experimental.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <IsPackable>true</IsPackable>

--- a/src/GraphQL.Extensions.Tracing/GraphQL.Extensions.Tracing.csproj
+++ b/src/GraphQL.Extensions.Tracing/GraphQL.Extensions.Tracing.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/GraphQL.Language/GraphQL.Language.csproj
+++ b/src/GraphQL.Language/GraphQL.Language.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net9.0;netstandard2.0</TargetFrameworks>
+        <TargetFrameworks>net9.0;net10.0;netstandard2.0</TargetFrameworks>
         <Nullable>enable</Nullable>
         <LangVersion>12</LangVersion>
         <IsPackable>true</IsPackable>
@@ -14,7 +14,7 @@
         <PackageReference Include="Microsoft.Bcl.HashCode" Version="1.1.1" />
     </ItemGroup>
 
-    <ItemGroup Condition=" '$(TargetFramework)' == 'net9.0' ">
+    <ItemGroup Condition=" '$(TargetFramework)' == 'net9.0' OR '$(TargetFramework)' == 'net10.0' ">
         <Compile Remove="Shims/**" />
         <Compile Remove="System.Diagnostics.CodeAnalysis/**" />
     </ItemGroup>

--- a/src/GraphQL.Language/GraphQL.Language.csproj
+++ b/src/GraphQL.Language/GraphQL.Language.csproj
@@ -14,7 +14,7 @@
         <PackageReference Include="Microsoft.Bcl.HashCode" Version="1.1.1" />
     </ItemGroup>
 
-    <ItemGroup Condition=" '$(TargetFramework)' == 'net9.0' OR '$(TargetFramework)' == 'net10.0' ">
+    <ItemGroup Condition=" '$(TargetFramework)' != 'netstandard2.0' ">
         <Compile Remove="Shims/**" />
         <Compile Remove="System.Diagnostics.CodeAnalysis/**" />
     </ItemGroup>

--- a/src/GraphQL.Server/GraphQL.Server.csproj
+++ b/src/GraphQL.Server/GraphQL.Server.csproj
@@ -18,10 +18,19 @@
 
 	<ItemGroup>
 		<FrameworkReference Include="Microsoft.AspNetCore.App" />
+		<PackageReference Include="System.Net.WebSockets" Version="4.3.0" />
+	</ItemGroup>
+
+	<ItemGroup Condition=" '$(TargetFramework)' == 'net9.0' ">
 		<PackageReference Include="Microsoft.Extensions.Options" Version="9.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Telemetry" Version="9.0.0" />
 		<PackageReference Include="System.IO.Pipelines" Version="9.0.0" />
-		<PackageReference Include="System.Net.WebSockets" Version="4.3.0" />
+	</ItemGroup>
+
+	<ItemGroup Condition=" '$(TargetFramework)' == 'net10.0' ">
+		<PackageReference Include="Microsoft.Extensions.Options" Version="10.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Telemetry" Version="10.0.0" />
+		<PackageReference Include="System.IO.Pipelines" Version="10.0.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/GraphQL.Server/GraphQL.Server.csproj
+++ b/src/GraphQL.Server/GraphQL.Server.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net9.0</TargetFramework>
+		<TargetFrameworks>net9.0;net10.0</TargetFrameworks>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<!-- Suppress nullable reference warnings for legacy code - these are pre-existing and not related to @oneOf migration -->

--- a/src/GraphQL/GraphQL.csproj
+++ b/src/GraphQL/GraphQL.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net9.0</TargetFrameworks>
+		<TargetFrameworks>net9.0;net10.0</TargetFrameworks>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<!-- Suppress nullable reference warnings for legacy code - these are pre-existing and not related to @oneOf migration -->

--- a/src/GraphQL/GraphQL.csproj
+++ b/src/GraphQL/GraphQL.csproj
@@ -12,9 +12,15 @@
 		<ProjectReference Include="..\GraphQL.Language\GraphQL.Language.csproj" />
 	</ItemGroup>
 
-	<ItemGroup>
+	<ItemGroup Condition=" '$(TargetFramework)' == 'net9.0' ">
 		<PackageReference Include="Microsoft.Extensions.Features" Version="9.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.0" />
 		<PackageReference Include="System.Text.Json" Version="9.0.0" />
+	</ItemGroup>
+
+	<ItemGroup Condition=" '$(TargetFramework)' == 'net10.0' ">
+		<PackageReference Include="Microsoft.Extensions.Features" Version="10.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.0" />
+		<PackageReference Include="System.Text.Json" Version="10.0.0" />
 	</ItemGroup>
 </Project>

--- a/tests/GraphQL.Extensions.ApolloFederation.Tests/GraphQL.Extensions.ApolloFederation.Tests.csproj
+++ b/tests/GraphQL.Extensions.ApolloFederation.Tests/GraphQL.Extensions.ApolloFederation.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/tests/GraphQL.Extensions.Experimental.Tests/GraphQL.Extensions.Experimental.Tests.csproj
+++ b/tests/GraphQL.Extensions.Experimental.Tests/GraphQL.Extensions.Experimental.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/tests/GraphQL.Extensions.Tracing.Tests/GraphQL.Extensions.Tracing.Tests.csproj
+++ b/tests/GraphQL.Extensions.Tracing.Tests/GraphQL.Extensions.Tracing.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/tests/GraphQL.Language.Tests/GraphQL.Language.Tests.csproj
+++ b/tests/GraphQL.Language.Tests/GraphQL.Language.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
 	  <Nullable>enable</Nullable>
 	  <!-- Suppress test warnings for legacy code - these are pre-existing and not related to @oneOf migration -->

--- a/tests/GraphQL.Server.SourceGenerators.Tests/GraphQL.Server.SourceGenerators.Tests.csproj
+++ b/tests/GraphQL.Server.SourceGenerators.Tests/GraphQL.Server.SourceGenerators.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net9.0</TargetFramework>
+		<TargetFrameworks>net9.0;net10.0</TargetFrameworks>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>

--- a/tests/GraphQL.Server.Tests/GraphQL.Server.Tests.csproj
+++ b/tests/GraphQL.Server.Tests/GraphQL.Server.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFrameworks>net9.0</TargetFrameworks>
+        <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 
@@ -18,7 +18,14 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup Condition=" '$(TargetFramework)' == 'net9.0' ">
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.0" />
+    </ItemGroup>
+
+    <ItemGroup Condition=" '$(TargetFramework)' == 'net10.0' ">
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/tests/GraphQL.Tests.Data/GraphQL.Mock.Data.csproj
+++ b/tests/GraphQL.Tests.Data/GraphQL.Mock.Data.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
 	  <IsPackable>false</IsPackable>
     <IsTestProject>false</IsTestProject>
   </PropertyGroup>

--- a/tests/GraphQL.Tests/GraphQL.Tests.csproj
+++ b/tests/GraphQL.Tests/GraphQL.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
 	  <Nullable>enable</Nullable>
   </PropertyGroup>
@@ -17,7 +17,6 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
-    <PackageReference Include="System.Text.Json" Version="9.0.0" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
       <PrivateAssets>all</PrivateAssets>
@@ -27,6 +26,14 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net9.0' ">
+    <PackageReference Include="System.Text.Json" Version="9.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net10.0' ">
+    <PackageReference Include="System.Text.Json" Version="10.0.0" />
   </ItemGroup>
   
   <ItemGroup>

--- a/tests/GraphQL.Tests/GraphQL.Tests.csproj
+++ b/tests/GraphQL.Tests/GraphQL.Tests.csproj
@@ -16,7 +16,6 @@
    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
-    <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
       <PrivateAssets>all</PrivateAssets>
@@ -29,6 +28,7 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net9.0' ">
+    <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="System.Text.Json" Version="9.0.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Add net10.0 target to all library projects while keeping source generators at netstandard2.0 for maximum compatibility.

Changes:
- GraphQL.Language: net9.0;net10.0;netstandard2.0
- GraphQL: net9.0;net10.0
- GraphQL.Server: net9.0;net10.0
- GraphQL.Extensions.ApolloFederation: net9.0;net10.0
- GraphQL.Extensions.Tracing: net9.0;net10.0
- GraphQL.Extensions.Experimental: net9.0;net10.0
- GraphQL.Server.SourceGenerators: netstandard2.0 (unchanged)